### PR TITLE
Change Type Naming, Remove not needed ContentItem saving

### DIFF
--- a/config/discord-raw.json
+++ b/config/discord-raw.json
@@ -56,7 +56,7 @@
       "interval": 3600000,
       "params": {
         "storage": "SQLiteStorage",
-        "source": "discord-raw",
+        "source": "discordRawData",
         "outputPath": "./output/discord/raw"
       }
     },
@@ -68,7 +68,7 @@
         "provider": "openAiProvider",
         "storage": "SQLiteStorage",
         "summaryType": "discordChannelSummary",
-        "source": "discord-raw",
+        "source": "discordRawData",
         "outputPath": "./output/discord/summaries"
       }
     }

--- a/src/plugins/generators/RawDataExporter.ts
+++ b/src/plugins/generators/RawDataExporter.ts
@@ -100,7 +100,7 @@ export class RawDataExporter {
         let baseFilename = `${dateStr}.json`; // Default filename
         logger.debug(`[RawDataExporter:${operation}] Determining path for item cid ${item.cid}, type ${item.type}...`);
 
-        if (item.type === 'discord-raw') {
+        if (item.type === 'discordRawData') {
              const guildName = item.metadata?.guildName || 'UnknownGuild'; 
              const channelName = item.metadata?.channelName || (parsedData as DiscordRawData)?.channel?.name || 'UnknownChannel';
              const sanitizedGuild = this.sanitizeName(guildName);

--- a/src/plugins/sources/DiscordRawDataSource.ts
+++ b/src/plugins/sources/DiscordRawDataSource.ts
@@ -449,7 +449,7 @@ export class DiscordRawDataSource implements ContentSource {
 
              items.push({
                 cid: `discord-raw-${channel.id}-${formattedDate}`,
-                type: 'discord-raw',
+                type: 'discordRawData',
                 source: `${guildName} - ${channel.name}`,
                 title: `Raw Discord Data: ${channel.name}`,
                 text: JSON.stringify(rawData),
@@ -510,7 +510,7 @@ export class DiscordRawDataSource implements ContentSource {
         if (rawData.messages.length > 0) {
           items.push({
             cid: `discord-raw-${channel.id}-${date}`,
-            type: 'discord-raw',
+            type: 'discordRawData',
             source: `${guildName} - ${channel.name}`,
             title: `Raw Discord Data: ${channel.name} (${date})`,
             text: JSON.stringify(rawData),

--- a/src/plugins/storage/SQLiteStorage.ts
+++ b/src/plugins/storage/SQLiteStorage.ts
@@ -247,12 +247,13 @@ export class SQLiteStorage implements StoragePlugin {
         await this.db.run(
           `
           UPDATE summary 
-          SET title = ?, categories = ?
+          SET title = ?, categories = ?, markdown = ?
           WHERE type = ? AND date = ?
           `,
           [
             item.title || null,
             item.categories || null,
+            item.markdown || null,
             item.type,
             item.date
           ]
@@ -262,13 +263,14 @@ export class SQLiteStorage implements StoragePlugin {
         // Insert new summary
         await this.db.run(
           `
-          INSERT INTO summary (type, title, categories, date)
-          VALUES (?, ?, ?, ?)
+          INSERT INTO summary (type, title, categories, markdown, date)
+          VALUES (?, ?, ?, ?, ?)
           `,
           [
             item.type,
             item.title || null,
             item.categories || null,
+            item.markdown || null,
             item.date,
           ]
         );

--- a/src/plugins/storage/SQLiteStorage.ts
+++ b/src/plugins/storage/SQLiteStorage.ts
@@ -55,6 +55,7 @@ export class SQLiteStorage implements StoragePlugin {
         type TEXT NOT NULL,
         title TEXT,
         categories TEXT,
+        markdown TEXT,
         date INTEGER
       );
     `);


### PR DESCRIPTION
## 🔄 PR: Normalize Discord Raw Data Type & Remove Channel Summaries

### Summary

This pull request refactors the handling of raw Discord data and Removes duplicate summaries of raw data being store in the items table. 

### ✅ Changes Included

#### 🔁 Type Refactor
- Renamed all `discord-raw` entries to `discordRawData` across:
  - `config/discord-raw.json`
  - `DiscordSummaryGenerator.ts`
  - `RawDataExporter.ts`
  - `DiscordRawDataSource.ts`

#### 🧹 Cleanup
- Removed all logic related to saving and handling `discordChannelSummary` content items:
  - Deleted `saveSummaryAsContentItem` method
  - Removed summary item saving code from processing loop

### 📉 Diff Summary
- **+8 / -53 LOC**
- Streamlined summary generation by focusing solely on raw data processing

### 🔍 Rationale
- Aligns with the new schema where `discordRawData` is the normalized type name
- Summarizing the raw content creates duplicate entries for future summaries. 
