### PR TITLE
Merge PR #59: channel state model fix, sync commands, ProgressDashboard

### DIFF
--- a/docs/community-profiles.md
+++ b/docs/community-profiles.md
@@ -1,0 +1,222 @@
+# Community Member Profiles — System Overview
+
+This document describes how we collect Discord community data, what we extract from it, how member profiles are generated, and where the current system has gaps. Written for external review and feedback.
+
+---
+
+## What We Collect
+
+### Source: Discord Chat Logs
+
+We ingest raw Discord message history across all channels in a server. For each channel per day we store:
+
+- **Messages** — text content, author ID, timestamp, reply references, reactions, @mentions
+- **Users** — Discord user ID, username, display name (nickname), roles, bot flag
+- **Threads** — thread participation and message counts
+
+This raw data is stored in a SQLite database per server. The M3 Metaverse Makers server has data from **April 2018 to present** — roughly 8 years.
+
+### Per-User Registry
+
+From the raw logs we build a `discord_users` table tracking:
+
+- User ID, username, all historical nicknames with date ranges
+- Roles held over time
+- Total message count
+- First seen / last seen dates
+- Avatar URL
+
+---
+
+## What We Extract (AI Pass)
+
+Each day's raw logs are processed by an LLM (GPT-4o-mini via OpenRouter) to extract structured data per channel:
+
+### FAQs
+Questions that came up in conversation, who asked, and who answered.
+
+```json
+{
+  "question": "How do I export avatars from Blender to VRM format?",
+  "askedBy": "someuser",
+  "answeredBy": "anotheruser"
+}
+```
+
+### Help Interactions
+Direct help exchanges with context and resolution.
+
+```json
+{
+  "helper": "avaer",
+  "helpee": "jin",
+  "context": "Jin asked about live lens undistortion for dual-lens VR",
+  "resolution": "avaer explained the shader approach and linked relevant code"
+}
+```
+
+### Action Items
+Tasks, proposals, and goals attributed to specific people — categorized as Technical, Feature, or Documentation.
+
+```json
+{
+  "type": "Technical",
+  "description": "Investigate WebGL memory leak in Exokit avatar loader",
+  "mentionedBy": "jin"
+}
+```
+
+These three structured arrays are stored per channel per day in the daily JSON summaries at `output/<server>/summaries/json/YYYY-MM-DD.json`.
+
+---
+
+## How Profiles Are Generated
+
+Profiles are built by running `npm run users -- generate-profiles --source=<server>.json` after accumulating daily summaries.
+
+### Step 1 — Aggregate across all dates
+
+For each display name that appears in the structured data, we collect across all available daily JSONs:
+
+| Signal | Source |
+|--------|--------|
+| `helpGiven` | All interactions where they were the `helper` |
+| `helpReceived` | All interactions where they were the `helpee` |
+| `questionsAsked` | All FAQs where they were `askedBy` |
+| `questionsAnswered` | All FAQs where they were `answeredBy` |
+| `actionItems` | All items where `mentionedBy` includes their name |
+| `activeDates` | Dates they appeared in the nicknameMap |
+
+### Step 2 — Sample across the full date range
+
+Rather than taking the most recent N items (which would bias toward recent activity), we split each array into three buckets — early, mid, recent — and sample evenly from each. This ensures the profile reflects the full arc of someone's activity, not just what they were doing last month.
+
+Sample sizes scale by activity tier:
+- **Core** (30+ active days): 20 help samples, 25 action items, 15 questions
+- **Regular** (5–29 days): 12 / 15 / 10
+- **Casual** (<5 days): 6 / 8 / 5
+
+### Step 3 — Generate structured profile via LLM
+
+The sampled evidence is sent to GPT-4o-mini with a journalist-style prompt: *"objective, grounded in evidence, no speculation, no flattery."* The model outputs a structured markdown document with fixed sections (see example below).
+
+### Step 4 — Delta updates
+
+Re-running `generate-profiles` on a profile that already exists triggers a delta pass: the existing profile + new evidence is sent to the LLM with instructions to update each section, correct outdated claims, and note any shifts in focus over time. This means profiles accumulate intelligence as more historical data is processed — they don't reset.
+
+### Step 5 — Inject into daily summaries
+
+The prose from `discord_users.notes` is injected into each day's `nicknameMap` as a `profile` field. When an LLM reads a daily summary and encounters a name, it has immediate context about who that person is.
+
+---
+
+## Profile Format
+
+Each profile is a markdown file at `output/<server>/summaries/users/<displayName>.md` with YAML frontmatter (machine-readable stats) and structured prose sections.
+
+### Example — jin (dankvr)
+
+```markdown
+---
+userId: "213767993153290250"
+username: "dankvr"
+displayName: "jin"
+roles: ["Owner", "M3", "Writer", "Dev", "Designer", "advisor", "devops", "🏘 Community"]
+activityTier: "core"
+generatedAt: "2026-03-22"
+dateRange: "2018-07-01/2026-03-19"
+helpGiven: 620
+helpReceived: 304
+questionsAsked: 1039
+questionsAnswered: 822
+actionItems: {Technical: 678, Feature: 727, Documentation: 341}
+activeDays: 425
+totalMessages: 224105
+---
+
+## Bio
+- Jin, known by the Discord username "dankvr," has been active in the community from July 1, 2018, to March 19, 2026.
+- He holds multiple roles, including Owner, M3, Writer, Developer, Designer, and Community Advisor.
+- Over his tenure, he has contributed a total of 224,105 messages to the server.
+- Jin is characterized as a helper and questioner, frequently assisting others while also seeking information and clarification on various topics.
+
+## Domains & Skills
+- Real-time camera-based mesh texturing using Meshroom and Blender
+- Cross-platform asset portability and NFT features in CryptoVoxels
+- 3D modeling and rendering techniques, including avatar workflows in VRM and Blender
+- Documentation and community engagement strategies for metaverse technologies
+- Technical troubleshooting for VR platforms such as Exokit and JanusVR
+- Integration of blockchain technologies and smart contracts in virtual environments
+
+## Communication Style
+Jin's communication is marked by a technical depth that reflects his expertise in virtual environments and blockchain technologies. He often employs a straightforward vocabulary register, asking specific, detail-oriented questions and providing structured, actionable answers. His voice can be described as analytical, inquisitive, and supportive.
+
+## Characteristic Questions & Quotes
+- "Can you type into the URL bar with a keyboard?" (2018-07)
+- "What resources are available for ENS integration?" (2019-09)
+- "Is Arweave a competitor to Filecoin?" (2019-11)
+- "What does avaer mean by 'smoke coins or unity'?" (2020-02)
+- "Should people be taking vitamin D during quarantine?" (2020-03)
+
+## Problems & Challenges
+- Technical issues with URL bar input and application crashes in Exokit.
+- Challenges related to optimizing asset exports for compatibility across different engines.
+- Seeking resources and examples for integrating various blockchain technologies and virtual goods.
+- Difficulty in navigating and utilizing existing VR tools and overlays effectively.
+
+## Goals & Projects
+- Technical: Develop a local-first cyberspace home concept; investigate and fix rendering issues on mobile devices; create a DApp for tokenized contracting.
+- Feature: Implement creative kick animations for user removal; add support for animated textures on avatars; explore cross-blockchain interoperability.
+- Documentation: Publish collaborative research on avatar standards; improve documentation regarding new API developments; review NFT guides for community education.
+
+## Help Patterns
+**Gives:** Jin reliably helps others with technical guidance on 3D modeling, asset portability, and troubleshooting VR platform issues, often providing concrete resources and examples.
+**Receives:** He seeks assistance primarily for technical challenges related to VR tools, asset optimization, and understanding blockchain integrations in virtual environments.
+
+## Temporal Arc
+In the early phase (2018-2019), Jin focused on foundational support and troubleshooting for emerging VR technologies. In the mid-phase (2020-2021), contributions shifted toward more complex technical projects and documentation, reflecting deepening engagement with community needs. In the recent phase (2022-2026), he has taken on a more organizational role, emphasizing collaborative projects and cross-platform interoperability.
+```
+
+---
+
+## Current Gaps
+
+### Data gaps
+
+**No resolution signal on help interactions.** We know who helped whom and what the context was, but we don't know if the help actually worked. Discord reactions (✅, 👍) from the original asker are a strong "resolved" signal — we have reaction data in the raw logs but don't currently use it.
+
+**Action items are never closed.** We extract action items attributed to people but have no mechanism to detect when they're completed. A task mentioned in 2022 looks identical to one mentioned yesterday. GitHub commit/PR data (which we also collect) could provide weak completion signals.
+
+**Nickname changes break attribution.** Someone who went by "jin" in 2018 and "jin (he/him)" in 2023 gets treated as two people during aggregation. We track nickname history with date ranges in the registry but don't yet use it to merge activity under a canonical identity.
+
+**No reaction or reply graph.** We don't extract who replied to whom or who reacted to whose messages. These are high-value signals for understanding expertise (being @-mentioned when someone has a question) and answer quality (reactions on answers).
+
+### Profile quality gaps
+
+**Quotes are questions, not statements.** The most extractable verbatim text we have is questions asked — which is useful for voice, but misses how someone *explains* things. Actual message content isn't passed to the profile generator, only AI-summarized interaction descriptions.
+
+**Profile is based on extracted summaries, not raw messages.** The FAQ/help/action item extraction is one LLM pass; the profile is a second LLM pass on top of that. Errors and omissions in the first pass compound. A person who is active but doesn't appear in help interactions or action items (e.g. a lurker who occasionally shares links) would have a thin profile despite real community value.
+
+**No sentiment or energy signal.** Whether someone is consistently enthusiastic, frequently frustrated, or going through a difficult period isn't captured. This kind of context matters for governance and retrospective analysis.
+
+**Skills are prose, not structured tags.** The `## Domains & Skills` section is human-readable but not machine-queryable. A downstream process wanting to answer "who knows WebXR?" has to parse prose rather than filter a tag array.
+
+### Scale gaps
+
+**Only one server at a time.** Some members are active across multiple servers (M3, ElizaOS, Hyperfy). Profiles are per-server — there's no cross-server identity merge to get a complete picture of someone's contributions across the ecosystem.
+
+**Profile generation requires prior summarization.** Profiles are only as good as the daily summaries that feed them. Running profiles before generating summaries for a full date range means you're working with incomplete data.
+
+---
+
+## What We're Thinking About Next
+
+- **Skill tag extraction** — a flat `skills: []` array in frontmatter derived from the Domains & Skills section, enabling simple lookup without prose parsing
+- **Reaction-based resolution scoring** — use existing reaction data to distinguish resolved vs unresolved help interactions
+- **Cross-server identity merge** — link profiles across servers by username for ecosystem-wide contributor pictures
+- **Unanswered question aggregation** — FAQs with `answeredBy: "Unanswered"` across all dates surface persistent community knowledge gaps and potential recruitment targets
+- **Collaboration graph** — post-process all profiles to build weighted edges between people who frequently help each other, once the full date range is summarized
+
+---
+
+*Generated from the [ai-news](https://github.com/M3-org/ai-news) pipeline. Data covers the M3 Metaverse Makers Discord server (guild 433492168825634816).*

--- a/docs/gap-detection-registry-fix.md
+++ b/docs/gap-detection-registry-fix.md
@@ -1,0 +1,142 @@
+# Gap Detection & Channel Registry Fix
+
+## What We Were Trying to Solve
+
+Two related problems in the historical data pipeline for `DiscordRawDataSource`:
+
+1. **Performance**: Range fetches (`--after/--before`) were making one DB query per channel per date to check if data already existed. For 156 channels × 2,893 dates = ~450k individual `getExistingCids` queries per mirror run.
+
+2. **Data quality**: The `discord_channels` registry had stale/wrong stats for 108/156 accessible channels — `lastActivityAt` was set to ancient dates (2018–2022), `activityHistory` had large gaps, and `currentVelocity` was near-zero for channels that were actually active.
+
+---
+
+## Root Causes Found
+
+### Bug 1: `connect()` zombie state (`DiscordRawDataSource.ts`)
+`_hasLoggedIn = true` was set **before** `await this._loginPromise`. If login threw, `_loginPromise` was never cleared and `_hasLoggedIn` stayed `true`. The next `connect()` call would wait forever for a `ready` event — permanent hang.
+
+### Bug 2: Cache miss fallback fires on empty dates (`DiscordRawDataSource.ts`)
+The preload cache used `this._existingCidsCache?.get(date) ?? await this.storage.getExistingCids(allCids)`. When the cache was populated but a date had no entries, `get(date)` returned `undefined`, triggering `??` and firing a full DB query — defeating the entire cache for newly-fetched dates.
+
+### Bug 3: Preload query ignored date range + called `getDb()` twice (`DiscordRawDataSource.ts`)
+`SELECT cid FROM items WHERE type = 'discordRawData'` scanned ALL rows ever with no date filter. For m3org with 306k rows this loaded the entire table on every range fetch. Also called `getDb()` twice unnecessarily.
+
+### Bug 4: `lastActivityAt` overwritten by backfill direction (`DiscordChannelRegistry.ts`)
+`recordActivity()` used `SET lastActivityAt = ?` (unconditional). During a newest→oldest historical backfill, every date call overwrote `lastActivityAt` with something older. After 2,893 iterations, it ended at the oldest date (`2018-04-11`) for channels that existed from the start. The 90-entry `activityHistory` cap also filled up mid-backfill, leaving a gap in recent history.
+
+When `mirror` ran with everything cached, `recordActivity` was never called at all, so stale values persisted indefinitely.
+
+---
+
+## Fixes Applied
+
+### `src/plugins/sources/DiscordRawDataSource.ts`
+
+**Fix 1 — zombie state:**
+```typescript
+// Before
+this._hasLoggedIn = true;
+this._loginPromise = this.client.login(this.botToken);
+await this._loginPromise;
+
+// After
+try {
+  this._loginPromise = this.client.login(this.botToken);
+  await this._loginPromise;
+  this._hasLoggedIn = true;  // only set on success
+} finally {
+  this._loginPromise = null;  // always cleared
+}
+```
+
+**Fix 2 — cache miss fallback:**
+```typescript
+// Before (undefined from .get() triggers ?? and fires DB query)
+this._existingCidsCache?.get(date) ?? await this.storage.getExistingCids(allCids)
+
+// After (explicit null check distinguishes "no cache" from "cache but empty date")
+this._existingCidsCache !== null
+  ? (this._existingCidsCache.get(date) ?? new Set<string>())
+  : await this.storage.getExistingCids(allCids)
+```
+
+**Fix 3 — scoped preload query:**
+```typescript
+// Before: scans entire table
+SELECT cid FROM items WHERE type = 'discordRawData'
+
+// After: scoped to range, uses idx_items_type_date index, getDb() called once
+const afterEpoch = Math.floor(new Date(after + 'T00:00:00Z').getTime() / 1000);
+const beforeEpoch = Math.floor(new Date(before + 'T00:00:00Z').getTime() / 1000) + 86400;
+SELECT cid FROM items WHERE type = 'discordRawData' AND date >= ? AND date < ?
+```
+
+### `src/plugins/storage/DiscordChannelRegistry.ts`
+
+**Fix 4 — prevent future `lastActivityAt` corruption:**
+```sql
+-- Before
+SET lastActivityAt = ?
+
+-- After (only moves forward, never backwards)
+SET lastActivityAt = MAX(COALESCE(lastActivityAt, 0), ?)
+```
+
+**New: `syncStats()` method** — rebuilds all 4 activity stats from `items.metadata.messageCount` without hitting Discord API:
+- Phase 1: all-time totals + latest fetch date (one GROUP BY query over full table)
+- Phase 2: per-day message counts for last 90 days (scoped by `idx_items_type_date`)
+- Recomputes `lastActivityAt`, `totalMessages`, `currentVelocity`, `activityHistory` for all channels
+
+### `scripts/channels.ts`
+
+- `mirror` now calls `registry.syncStats()` automatically after the subprocess completes
+- New `channels sync-stats` standalone command for one-off repairs
+- Enhanced `channels stats` output: shows actual message coverage (records with content vs empty), channels active in last 30/90 days with counts, coverage date range
+
+---
+
+## Current State (m3org.sqlite)
+
+After running `npm run channels -- sync-stats --source=m3org.json`:
+
+| Metric | Before | After |
+|---|---|---|
+| Channels with stale `lastActivityAt` (pre-2024) | 108/156 | 0/156 |
+| `lastActivityAt` accuracy | Wrong (oldest date from backfill) | Correct (latest fetch date) |
+| `activityHistory` | Gap-filled from mid-backfill | Correct last 90 days |
+| `currentVelocity` | Near-zero for most channels | Reflects actual recent activity |
+
+Raw data coverage: 306,435 records, 2018-04-11 → 2026-03-12, complete (no gaps).
+
+Active channels (last 90 days): 27 out of 156 accessible. The rest are archived/dead — empty records are correct.
+
+---
+
+## Blockers / Open Questions
+
+1. **`mirror` still closes quickly** — this is correct behavior when all data is already present. But there's no easy way to tell "data is complete" vs "mirror is broken" from the outside. A dry-run mode showing coverage gaps would help.
+
+2. **Empty records vs truly missing data** — 274,333 of 306,435 records are `empty=true` (channels had no messages that day). This is real, but hard to distinguish from "was never properly fetched." The early-exit optimization (`lastMessageId < startOfDay`) fires for dead channels and saves an empty record — correct, but opaque.
+
+3. **`totalMessages` in registry can double-count** — `recordActivity` uses `totalMessages = totalMessages + messageCount` (cumulative increment). If a channel date is ever re-fetched with FORCE_OVERWRITE, the count inflates. `syncStats()` resets it correctly from items, but it drifts again after the next fetch. Consider switching to a direct `SUM` query for display instead of maintaining a running counter.
+
+4. **`activityHistory` capped at 90 entries** — fine for velocity, but means the registry only "knows" recent activity. Long-dead channels look identical to channels that just started. The `last_msg_date` from items is more reliable for determining true channel health.
+
+---
+
+## Related Commands
+
+```bash
+# Fix stale registry stats (safe to run anytime)
+npm run channels -- sync-stats --source=m3org.json
+
+# Check what's actually in the DB
+npm run channels -- stats --source=m3org.json
+
+# Force-refetch a specific date range (ignores cache)
+FORCE_OVERWRITE=true npm run historical -- --source=m3org.json \
+  --after=2026-03-01 --before=2026-03-12 --onlyFetch
+
+# Generate summaries from existing raw data
+npm run channels -- archive --after=YYYY-MM-DD --before=YYYY-MM-DD --source=m3org.json
+```

--- a/scripts/channels.ts
+++ b/scripts/channels.ts
@@ -14,6 +14,7 @@
  *   npm run channels -- analyze [--all] [--channel=ID]
  *   npm run channels -- propose [--dry-run]
  *   npm run channels -- list [--tracked|--active|--muted|--quiet]
+ *   npm run channels -- list --interactive --source=m3org.json
  *   npm run channels -- show <channelId>
  *   npm run channels -- stats
  *   npm run channels -- track <channelId>
@@ -25,10 +26,11 @@
 
 import { open, Database } from "sqlite";
 import sqlite3 from "sqlite3";
-import { Client, GatewayIntentBits, ChannelType, TextChannel } from "discord.js";
+import { Client, GatewayIntentBits, ChannelType, TextChannel, ForumChannel } from "discord.js";
 import OpenAI from "openai";
 import * as fs from "fs";
 import * as path from "path";
+import * as readline from "readline";
 import * as dotenv from "dotenv";
 import {
   DiscordChannelRegistry,
@@ -78,13 +80,15 @@ interface CliArgs {
   // Config filter
   source?: string;
   json?: boolean;
-}
-
-interface DiscordRawData {
-  channel: { id: string; name: string; topic?: string; category?: string; guildId?: string; guildName?: string };
-  date: string;
-  users: Record<string, any>;
-  messages: Array<{ id: string; uid: string; content: string }>;
+  // Date range (for archive)
+  after?: string;
+  before?: string;
+  output?: string;
+  force?: boolean;
+  apply?: boolean;
+  interactive?: boolean;
+  // Sync options
+  withFetch?: boolean;
 }
 
 interface DiscordSourceConfig {
@@ -112,6 +116,7 @@ interface DiscordRawData {
     id: string;
     uid: string;
     content: string;
+    ts?: string;
     timestamp?: string;
   }>;
 }
@@ -161,6 +166,13 @@ function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
     else if (arg.startsWith("--channel=")) args.channelId = arg.split("=")[1];
     else if (arg.startsWith("--source=")) args.source = arg.split("=")[1];
     else if (arg === "--json") args.json = true;
+    else if (arg.startsWith("--after=")) args.after = arg.split("=")[1];
+    else if (arg.startsWith("--before=")) args.before = arg.split("=")[1];
+    else if (arg.startsWith("--output=")) args.output = arg.split("=")[1];
+    else if (arg === "-f" || arg === "--force") args.force = true;
+    else if (arg === "--apply") args.apply = true;
+    else if (arg === "--interactive") args.interactive = true;
+    else if (arg === "--with-fetch") args.withFetch = true;
   }
 
   return args;
@@ -216,11 +228,7 @@ function getTrackedChannelIds(configs: Map<string, LoadedConfig>): Map<string, S
 
   for (const [, configData] of configs) {
     for (const source of configData.discordSources) {
-      let guildId = source.params?.guildId || "unknown";
-      if (guildId.startsWith("process.env.")) {
-        const envVar = guildId.replace("process.env.", "");
-        guildId = process.env[envVar] || envVar;
-      }
+      const guildId = resolveConfigEnvValue(source.params?.guildId) || "unknown";
       const channelIds = source.params?.channelIds || [];
 
       if (!trackedChannels.has(guildId)) {
@@ -236,13 +244,19 @@ function getTrackedChannelIds(configs: Map<string, LoadedConfig>): Map<string, S
   return trackedChannels;
 }
 
+function resolveConfigEnvValue(value?: string): string | undefined {
+  if (!value) return undefined;
+  if (!value.startsWith("process.env.")) return value;
+  const envVar = value.replace("process.env.", "");
+  return process.env[envVar] || envVar;
+}
+
 function getGuildIds(configs: Map<string, LoadedConfig>): Set<string> {
   const guildIds = new Set<string>();
 
   for (const [, configData] of configs) {
     for (const source of configData.discordSources) {
-      const guildIdVar = source.params?.guildId?.replace("process.env.", "");
-      const guildId = guildIdVar ? process.env[guildIdVar] : source.params?.guildId;
+      const guildId = resolveConfigEnvValue(source.params?.guildId);
       if (guildId) {
         guildIds.add(guildId);
       }
@@ -250,6 +264,67 @@ function getGuildIds(configs: Map<string, LoadedConfig>): Set<string> {
   }
 
   return guildIds;
+}
+
+function resolveDiscordBotToken(configs: Map<string, LoadedConfig>): {
+  token: string | null;
+  configName: string | null;
+  tokenVar: string | null;
+} {
+  for (const [configName, configData] of configs) {
+    for (const source of configData.discordSources) {
+      const tokenVar = source.params?.botToken?.replace("process.env.", "");
+      if (tokenVar && process.env[tokenVar]) {
+        return {
+          token: process.env[tokenVar]!,
+          configName,
+          tokenVar,
+        };
+      }
+    }
+  }
+
+  return { token: null, configName: null, tokenVar: null };
+}
+
+function filterChannelsByGuildIds(channels: DiscordChannel[], guildIds: Set<string>): DiscordChannel[] {
+  if (guildIds.size === 0) {
+    return channels;
+  }
+  return channels.filter(channel => guildIds.has(channel.guildId));
+}
+
+function isSupportedSyncChannel(channel: any): channel is TextChannel | ForumChannel {
+  return channel?.type === ChannelType.GuildText ||
+    channel?.type === ChannelType.GuildForum ||
+    channel?.type === ChannelType.GuildAnnouncement;
+}
+
+async function upsertRegistryChannelFromDiscord(
+  registry: DiscordChannelRegistry,
+  channel: TextChannel | ForumChannel,
+  observedAt: string,
+  isTracked: boolean
+): Promise<void> {
+  const textChannel = channel as TextChannel;
+  const forumChannel = channel as ForumChannel;
+
+  await registry.upsertChannel({
+    id: channel.id,
+    guildId: channel.type === ChannelType.GuildForum ? forumChannel.guild.id : textChannel.guild.id,
+    guildName: channel.type === ChannelType.GuildForum ? forumChannel.guild.name : textChannel.guild.name,
+    name: channel.type === ChannelType.GuildForum ? forumChannel.name : textChannel.name,
+    topic: channel.type === ChannelType.GuildForum ? forumChannel.topic : textChannel.topic,
+    categoryId: channel.type === ChannelType.GuildForum ? forumChannel.parentId : textChannel.parentId,
+    categoryName: channel.type === ChannelType.GuildForum ? forumChannel.parent?.name || null : textChannel.parent?.name || null,
+    type: channel.type,
+    position: channel.type === ChannelType.GuildForum ? forumChannel.position : textChannel.position,
+    nsfw: channel.type === ChannelType.GuildForum ? forumChannel.nsfw : textChannel.nsfw,
+    rateLimitPerUser: channel.type === ChannelType.GuildText ? textChannel.rateLimitPerUser : 0,
+    createdAt: Math.floor((channel.createdTimestamp || Date.now()) / 1000),
+    observedAt,
+    isTracked
+  });
 }
 
 // ============================================================================
@@ -274,17 +349,10 @@ async function commandDiscover(db: Database, args: CliArgs): Promise<void> {
   }
 
   // Find a valid Discord token
-  let botToken: string | null = null;
-  for (const [configName, configData] of configs) {
-    for (const source of configData.discordSources) {
-      const tokenVar = source.params?.botToken?.replace("process.env.", "");
-      if (tokenVar && process.env[tokenVar]) {
-        botToken = process.env[tokenVar]!;
-        console.log(`Using token from ${configName} (${tokenVar})`);
-        break;
-      }
-    }
-    if (botToken) break;
+  const tokenInfo = resolveDiscordBotToken(configs);
+  const botToken = tokenInfo.token;
+  if (botToken && tokenInfo.configName && tokenInfo.tokenVar) {
+    console.log(`Using token from ${tokenInfo.configName} (${tokenInfo.tokenVar})`);
   }
 
   // Fallback to building from raw data if no Discord token
@@ -308,13 +376,12 @@ async function commandDiscover(db: Database, args: CliArgs): Promise<void> {
     process.exit(1);
   }
 
-  // Load muted channels from existing registry
-  const existingChannels = await registry.getAllChannels();
-  const mutedChannels = new Set<string>(
-    existingChannels.filter(c => c.isMuted).map(c => c.id)
+  // Load previously unavailable channels from registry
+  const unavailableChannels = new Set<string>(
+    (await registry.getUnavailableChannels()).map(c => c.id)
   );
-  if (mutedChannels.size > 0) {
-    console.log(`Loaded ${mutedChannels.size} muted channels from registry\n`);
+  if (unavailableChannels.size > 0) {
+    console.log(`Loaded ${unavailableChannels.size} previously unavailable channels from registry\n`);
   }
 
   // Get tracked channels from config
@@ -334,6 +401,7 @@ async function commandDiscover(db: Database, args: CliArgs): Promise<void> {
   const guildIds = getGuildIds(configs);
   const allChannels = new Map<string, { guild: any; channels: Map<string, TextChannel> }>();
   const channelActivity = new Map<string, ChannelActivity>();
+  let revalidatedDuringDiscovery = 0;
 
   console.log("Discovering channels...");
   let guildIndex = 0;
@@ -368,23 +436,16 @@ async function commandDiscover(db: Database, args: CliArgs): Promise<void> {
 
       for (const [channelId, channel] of textChannels) {
         try {
-          await registry.upsertChannel({
-            id: channelId,
-            guildId: guildId,
-            guildName: guild.name,
-            name: channel.name,
-            topic: channel.topic || null,
-            categoryId: channel.parentId || null,
-            categoryName: channel.parent?.name || null,
-            type: channel.type,
-            position: channel.position,
-            nsfw: channel.nsfw,
-            rateLimitPerUser: channel.rateLimitPerUser || 0,
-            createdAt: Math.floor(channel.createdTimestamp! / 1000),
+          await upsertRegistryChannelFromDiscord(
+            registry,
+            channel,
             observedAt,
-            isTracked: tracked.has(channelId),
-            isMuted: mutedChannels.has(channelId)
-          });
+            tracked.has(channelId)
+          );
+          if (unavailableChannels.delete(channelId)) {
+            await registry.clearUnavailable(channelId);
+            revalidatedDuringDiscovery++;
+          }
         } catch (error: any) {
           if (args.debug) {
             console.error(`    Failed to upsert channel ${channelId}: ${error.message}`);
@@ -479,11 +540,11 @@ async function commandDiscover(db: Database, args: CliArgs): Promise<void> {
           });
           errors++;
 
-          // Auto-mute inaccessible channels (but not tracked ones)
+          // Mark inaccessible channels as unavailable (but not tracked ones)
           const tracked = trackedChannels.get(guildId)?.has(channelId);
-          if (!mutedChannels.has(channelId) && !tracked) {
-            mutedChannels.add(channelId);
-            await registry.setMuted(channelId, true);
+          if (!tracked) {
+            await registry.markUnavailable(channelId, (error as any).message || "Bot lacks access");
+            unavailableChannels.add(channelId);
           }
         }
       }
@@ -498,7 +559,10 @@ async function commandDiscover(db: Database, args: CliArgs): Promise<void> {
   console.log("\n Channel discovery complete!");
   console.log(`\nRegistry now contains ${stats.totalChannels} channels`);
   console.log(`  Tracked: ${stats.trackedChannels}`);
-  console.log(`  Muted: ${stats.mutedChannels}`);
+  console.log(`  Unavailable: ${unavailableChannels.size}`);
+  if (revalidatedDuringDiscovery > 0) {
+    console.log(`  Revalidated access: ${revalidatedDuringDiscovery}`);
+  }
   console.log("\nNext steps:");
   console.log("1. Run 'npm run channels -- analyze --stale' to analyze channels with LLM");
   console.log("2. Run 'npm run channels -- propose' to generate config changes");
@@ -556,9 +620,13 @@ function getActivityBadge(velocity: number, daysSinceActivity?: number): string 
 // Command: analyze
 // ============================================================================
 
-async function loadChannelMessages(db: Database, channelId: string, limit: number = 100): Promise<string[]> {
-  const rows = await db.all<Array<{ text: string }>>(
-    `SELECT text FROM items
+async function loadChannelMessages(
+  db: Database,
+  channelId: string,
+  limit: number = 100
+): Promise<{ messages: string[]; lastMsgDate: string | null }> {
+  const rows = await db.all<Array<{ text: string; date: number }>>(
+    `SELECT text, date FROM items
      WHERE type = 'discordRawData'
        AND json_extract(text, '$.channel.id') = ?
      ORDER BY date DESC
@@ -567,14 +635,21 @@ async function loadChannelMessages(db: Database, channelId: string, limit: numbe
   );
 
   const messages: string[] = [];
+  let lastMsgDate: string | null = null;
+
   for (const row of rows) {
     try {
       const data: DiscordRawData = JSON.parse(row.text);
       for (const msg of data.messages) {
+        const msgTs = msg.ts || msg.timestamp;
+        if (msgTs && (!lastMsgDate || msgTs > lastMsgDate)) {
+          lastMsgDate = msgTs.split("T")[0];
+        }
         if (!msg.content.trim()) continue;
         const user = data.users[msg.uid];
-        const username = user?.displayName || user?.nickname || user?.username || "Unknown";
-        messages.push(`[${username}]: ${msg.content.slice(0, 500)}`);
+        const username = (user as any)?.name || user?.nickname || msg.uid;
+        const botTag = (user as any)?.isBot ? " [BOT]" : "";
+        messages.push(`[${username}${botTag}]: ${msg.content.slice(0, 500)}`);
         if (messages.length >= limit) break;
       }
     } catch (e) {
@@ -583,7 +658,71 @@ async function loadChannelMessages(db: Database, channelId: string, limit: numbe
     if (messages.length >= limit) break;
   }
 
-  return messages;
+  return { messages, lastMsgDate };
+}
+
+function formatChannelProfile(channel: DiscordChannel, messages: string[], lastMsgDate: string | null): string {
+  const lastActivity = lastMsgDate || (channel.lastActivityAt
+    ? new Date(channel.lastActivityAt * 1000).toISOString().split("T")[0]
+    : "unknown");
+  const velocity = channel.currentVelocity > 0
+    ? `${channel.currentVelocity.toFixed(1)} msgs/day (all-time avg)`
+    : "inactive";
+  const msgBlock = messages.length > 0
+    ? messages.map(m => `  ${m}`).join("\n")
+    : "  (no messages in database)";
+  return [
+    `Activity: ${velocity} | ${channel.totalMessages} total msgs | Last active: ${lastActivity}`,
+    `Category: ${channel.categoryName || "none"}`,
+    `Recent messages:\n${msgBlock}`,
+  ].join("\n");
+}
+
+async function batchAnalyzeChannels(
+  openai: OpenAI,
+  model: string,
+  channels: DiscordChannel[]
+): Promise<Map<string, AIAnalysisResult>> {
+  const today = new Date().toISOString().split("T")[0];
+
+  const channelSections = channels.map(ch =>
+    `### #${ch.name} (ID: ${ch.id})\n${ch.notes || "(no profile)"}`
+  ).join("\n\n---\n\n");
+
+  const prompt = `All channels below had activity in the last 7 days. Classify each as TRACK or MAYBE only.
+
+${channelSections}
+
+---
+
+Rules:
+- TRACK: Multiple different users having back-and-forth conversation.
+- MAYBE: Single user posting, bot-only feed, or only link dumps with no replies.
+
+Respond ONLY with a JSON array using the exact IDs provided:
+[{"id":"<channel_id>","recommendation":"TRACK|MAYBE","reason":"10 words max"}, ...]`;
+
+  const completion = await (openai.chat.completions.create as any)({
+    model,
+    messages: [{ role: "user", content: prompt }],
+    temperature: 0,
+    max_tokens: 16384,
+    ...(process.env.USE_OPENROUTER === "true" ? { reasoning: { effort: "none" } } : {})
+  });
+
+  let content = completion.choices[0]?.message?.content ||
+                completion.choices[0]?.message?.reasoning || "";
+  content = content.replace(/<think>[\s\S]*?<\/think>/g, "").trim();
+
+  const jsonMatch = content.match(/\[[\s\S]*\]/);
+  if (!jsonMatch) throw new Error(`No JSON array in response: ${content.slice(0, 300)}`);
+
+  const results: Array<{ id: string; recommendation: AIRecommendation; reason: string }> = JSON.parse(jsonMatch[0]);
+  const map = new Map<string, AIAnalysisResult>();
+  for (const r of results) {
+    map.set(r.id, { recommendation: r.recommendation, reason: r.reason || "" });
+  }
+  return map;
 }
 
 async function analyzeChannelWithLLM(
@@ -592,31 +731,42 @@ async function analyzeChannelWithLLM(
   channel: DiscordChannel,
   messagesText: string
 ): Promise<AIAnalysisResult | null> {
-  const prompt = `Analyze these Discord messages from #${channel.name}.
+  const categoryInfo = channel.categoryName ? ` (category: ${channel.categoryName})` : "";
+  const velocityInfo = channel.currentVelocity > 0 ? `${channel.currentVelocity.toFixed(1)} msgs/day (all-time avg)` : "inactive";
+  const lastActivityInfo = channel.lastActivityAt
+    ? `Last message: ${new Date(channel.lastActivityAt * 1000).toISOString().split("T")[0]}`
+    : "Last message: unknown";
+  const today = new Date().toISOString().split("T")[0];
+  const prompt = `Today is ${today}. Analyze this Discord channel #${channel.name}${categoryInfo}.
+Activity: ${velocityInfo}, ${channel.totalMessages} total messages. ${lastActivityInfo}.
 
-Messages:
+Recent messages (users tagged [BOT] are bots/webhooks):
 ${messagesText}
 
-Respond ONLY with valid JSON:
+Respond ONLY with valid JSON, no thinking:
 {
   "recommendation": "TRACK|MAYBE|SKIP",
   "reason": "brief explanation (15 words max)"
 }
 
 Guidelines:
-- TRACK: Technical content, development discussion, code sharing, valuable for documentation
-- MAYBE: Mixed content, occasional useful info, could be filtered
-- SKIP: Bot spam, price talk, low signal, no documentation value`;
+- TRACK: Active channel with recent messages (within last few months) and substantive discussion — technical, creative, governance, problem-solving.
+- MAYBE: Mixed signal — some useful content but inconsistent activity, or last activity was months ago.
+- SKIP: One-way feeds (webhook dumps, commit logs, RSS), join/leave spam, pure price/trading talk, no real conversation, or dormant (last message over 1 month ago).`;
 
   try {
-    const completion = await openai.chat.completions.create({
+    const completion = await (openai.chat.completions.create as any)({
       model,
       messages: [{ role: "user", content: prompt }],
       temperature: 0,
-      max_tokens: 150
+      max_tokens: 4096,
+      ...(process.env.USE_OPENROUTER === "true" ? { reasoning: { effort: "none" } } : {})
     });
 
-    const content = completion.choices[0]?.message?.content || "";
+    let content = completion.choices[0]?.message?.content ||
+                  completion.choices[0]?.message?.reasoning || "";
+    // Strip <think> tags in case reasoning leaked through
+    content = content.replace(/<think>[\s\S]*?<\/think>/g, "").trim();
 
     // Try to extract JSON from response
     const jsonMatch = content.match(/\{[\s\S]*\}/);
@@ -628,12 +778,16 @@ Guidelines:
       };
     }
 
-    throw new Error("No JSON found in response");
+    throw new Error(`No JSON found in response: ${content.slice(0, 300)}`);
   } catch (error: any) {
     console.error(`    LLM error for #${channel.name}: ${error.message}`);
     return null;
   }
 }
+
+// ============================================================================
+// Command: summarize
+// ============================================================================
 
 async function summarizeChannelWithLLM(
   openai: OpenAI,
@@ -746,7 +900,7 @@ async function commandSummarize(db: Database, registry: DiscordChannelRegistry, 
     summarizeSpinner.text = stepProgress(i + 1, channelsToSummarize.length, `Summarizing #${channel.name}`);
     process.stdout.write(`  Summarizing #${channel.name.padEnd(25)}...`);
 
-    const messages = await loadChannelMessages(db, channel.id, 100);
+    const { messages } = await loadChannelMessages(db, channel.id, 100);
 
     if (messages.length === 0) {
       console.log(" no messages");
@@ -809,10 +963,14 @@ async function commandAnalyze(db: Database, registry: DiscordChannelRegistry, ar
     } : undefined
   });
 
-  const model = "openai/gpt-5.4-nano";
+  const model = process.env.CHANNEL_ANALYZE_MODEL ||
+    (process.env.USE_OPENROUTER === "true" ? "qwen/qwen3.5-35b-a3b" : "gpt-4o-mini");
 
   // Determine which channels to analyze
   let channelsToAnalyze: DiscordChannel[];
+  let tracked = 0;
+  let maybe = 0;
+  let skip = 0;
 
   if (args.channelId) {
     // Single channel mode
@@ -824,9 +982,19 @@ async function commandAnalyze(db: Database, registry: DiscordChannelRegistry, ar
     channelsToAnalyze = [channel];
     console.log(`Analyzing single channel: #${channel.name}`);
   } else if (args.all) {
-    // All non-muted channels with activity
-    channelsToAnalyze = (await registry.getAllChannels()).filter(c => !c.isMuted && c.currentVelocity > 0);
-    console.log(`Analyzing all ${channelsToAnalyze.length} active channels`);
+    const allChannels = await registry.getAllChannels();
+
+    // Unavailable channels (bot can't access) — stamp SKIP if not already analyzed
+    const unavailable = allChannels.filter(c => c.unavailableReason && !c.aiLastAnalyzed);
+    for (const ch of unavailable) {
+      await registry.updateAIAnalysis(ch.id, { recommendation: "SKIP", reason: "Channel inaccessible" });
+      skip++;
+    }
+    skip += allChannels.filter(c => c.unavailableReason && c.aiLastAnalyzed).length;
+
+    // channelsToAnalyze: non-unavailable, non-muted (muted = user choice, still might have data)
+    channelsToAnalyze = allChannels.filter(c => !c.unavailableReason && !c.isMuted);
+    console.log(`Analyzing ${channelsToAnalyze.length} accessible channels (${unavailable.length} unavailable pre-stamped SKIP)`);
   } else {
     // Default: channels needing analysis (never analyzed or >30 days old)
     channelsToAnalyze = await registry.getChannelsNeedingAnalysis(30);
@@ -842,62 +1010,101 @@ async function commandAnalyze(db: Database, registry: DiscordChannelRegistry, ar
   if (args.dryRun) {
     analyzeSpinner.stop();
     console.log(`\nDry run — would analyze ${channelsToAnalyze.length} channel(s).`);
-    console.log(`Estimated API calls: ${channelsToAnalyze.length}`);
+    const estimatedCalls = args.channelId ? channelsToAnalyze.length : 1;
+    console.log(`Estimated API calls: ${estimatedCalls} (${args.channelId ? "per-channel" : "batch"})`);
     return;
   }
 
   console.log("");
 
-  // Analyze each channel
-  let analyzed = 0;
-  let tracked = 0;
-  let maybe = 0;
-  let skip = 0;
-  let errors = 0;
+  // Build profiles for all channels (no per-channel LLM)
+  console.log("Building channel profiles...");
+  const RECENCY_DAYS = 7;
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - RECENCY_DAYS);
+  const cutoffStr = cutoff.toISOString().split("T")[0];
+
+  const noMessages: DiscordChannel[] = [];
+  const stale: DiscordChannel[] = [];
+  const toClassify: DiscordChannel[] = [];
+  const profileRows: Array<{ channel: DiscordChannel; lastMsgDate: string | null }> = [];
 
   for (let i = 0; i < channelsToAnalyze.length; i++) {
     const channel = channelsToAnalyze[i];
-    analyzeSpinner.text = stepProgress(i + 1, channelsToAnalyze.length, `Analyzing #${channel.name}`);
-    process.stdout.write(`  Analyzing #${channel.name.padEnd(25)}...`);
-
-    // Load messages for this channel
-    const messages = await loadChannelMessages(db, channel.id, 50);
-
+    analyzeSpinner.text = stepProgress(i + 1, channelsToAnalyze.length, `Profiling #${channel.name}`);
+    const { messages, lastMsgDate } = await loadChannelMessages(db, channel.id, 10);
+    const profile = formatChannelProfile(channel, messages, lastMsgDate);
+    await registry.updateNotes(channel.id, profile);
+    channel.notes = profile;
+    profileRows.push({ channel, lastMsgDate });
     if (messages.length === 0) {
-      console.log(" no messages");
-      continue;
-    }
-
-    const messagesText = messages.join("\n");
-    const analysis = await analyzeChannelWithLLM(openai, model, channel, messagesText);
-
-    if (analysis) {
-      await registry.updateAIAnalysis(channel.id, analysis);
-      console.log(` ${analysis.recommendation}`);
-
-      if (analysis.recommendation === "TRACK") tracked++;
-      else if (analysis.recommendation === "MAYBE") maybe++;
-      else skip++;
-
-      analyzed++;
+      noMessages.push(channel);
+    } else if (!lastMsgDate || lastMsgDate < cutoffStr) {
+      stale.push(channel);
     } else {
-      console.log(" ERROR");
-      errors++;
+      toClassify.push(channel);
     }
-
-    // Rate limiting
-    await sleep(200);
   }
 
+  // Stats table
+  analyzeSpinner.stop();
+  console.log("\n| name | lastMsgDate | currentVelocity | totalMessages | aiRecommendation |");
+  console.log("|------|-------------|-----------------|---------------|-----------------|");
+  for (const { channel, lastMsgDate } of profileRows) {
+    const date = lastMsgDate ?? "—";
+    const vel = channel.currentVelocity > 0 ? `${channel.currentVelocity.toFixed(1)}/day` : "—";
+    const rec = channel.aiRecommendation ?? "—";
+    console.log(`| #${channel.name} | ${date} | ${vel} | ${channel.totalMessages} | ${rec} |`);
+  }
+  console.log("");
+
+  // Pre-classify channels with no messages as SKIP (no LLM needed)
+  for (const channel of noMessages) {
+    const analysis: AIAnalysisResult = { recommendation: "SKIP", reason: "No messages in database" };
+    await registry.updateAIAnalysis(channel.id, analysis);
+    skip++;
+  }
+
+  // Pre-classify stale channels as SKIP (no LLM needed)
+  for (const channel of stale) {
+    const analysis: AIAnalysisResult = { recommendation: "SKIP", reason: "No messages in last 7 days" };
+    await registry.updateAIAnalysis(channel.id, analysis);
+    skip++;
+  }
+
+  if (toClassify.length > 0) {
+    // Single batch LLM call for all channels with recent data
+    console.log(`Running batch analysis (1 LLM call for ${toClassify.length} channels)...`);
+    analyzeSpinner.text = "Running batch LLM analysis...";
+    analyzeSpinner.start();
+    const resultsMap = await batchAnalyzeChannels(openai, model, toClassify);
+
+    analyzeSpinner.stop();
+    console.log("\n| name | aiRecommendation | aiReason |");
+    console.log("|------|-----------------|---------|");
+    for (const channel of toClassify) {
+      const analysis = resultsMap.get(channel.id);
+      if (analysis) {
+        await registry.updateAIAnalysis(channel.id, analysis);
+        console.log(`| #${channel.name} | ${analysis.recommendation} | ${analysis.reason} |`);
+        if (analysis.recommendation === "TRACK") tracked++;
+        else if (analysis.recommendation === "MAYBE") maybe++;
+        else skip++;
+      } else {
+        console.log(`| #${channel.name} | — | (no result) |`);
+      }
+    }
+    console.log("");
+  }
+
+
   console.log(`\nAnalysis complete!`);
-  console.log(`  Analyzed: ${analyzed}`);
   console.log(`  TRACK: ${tracked}`);
   console.log(`  MAYBE: ${maybe}`);
   console.log(`  SKIP: ${skip}`);
-  console.log(`  Errors: ${errors}`);
   console.log("\nNext steps:");
   console.log("1. Run 'npm run channels -- propose' to generate config changes");
-  analyzeSpinner.succeed("Channel analysis complete");
+  console.log("Channel analysis complete");
 }
 
 // ============================================================================
@@ -986,6 +1193,47 @@ async function commandProposeUpdate(db: Database, registry: DiscordChannelRegist
   if (args.dryRun) {
     console.error(`\n[DRY RUN] Would create PR with ${toAdd.length} additions and ${toRemove.length} removals`);
   }
+
+  // --apply: write changes directly back to config file(s)
+  if (args.apply && !args.dryRun) {
+    const configs = loadConfigs(args.source);
+    let totalAdded = 0;
+    let totalRemoved = 0;
+
+    for (const [configName, configData] of configs) {
+      let modified = false;
+
+      for (const source of configData.discordSources) {
+        const channelIds: string[] = source.params?.channelIds || [];
+
+        for (const ch of toAdd) {
+          if (!channelIds.includes(ch.channelId)) {
+            channelIds.push(ch.channelId);
+            modified = true;
+            totalAdded++;
+          }
+        }
+
+        for (const ch of toRemove) {
+          const idx = channelIds.indexOf(ch.channelId);
+          if (idx !== -1) {
+            channelIds.splice(idx, 1);
+            modified = true;
+            totalRemoved++;
+          }
+        }
+
+        source.params.channelIds = channelIds;
+      }
+
+      if (modified) {
+        fs.writeFileSync(configData.path, JSON.stringify(configData.config, null, 2) + "\n");
+        console.error(`Applied to ${configName}: +${totalAdded} added, -${totalRemoved} removed`);
+      } else {
+        console.error(`No changes needed in ${configName}`);
+      }
+    }
+  }
 }
 
 // ============================================================================
@@ -993,6 +1241,11 @@ async function commandProposeUpdate(db: Database, registry: DiscordChannelRegist
 // ============================================================================
 
 async function commandList(registry: DiscordChannelRegistry, args: CliArgs): Promise<void> {
+  if (args.interactive) {
+    await commandInteractiveTrackSelection(registry, args);
+    return;
+  }
+
   let channels: DiscordChannel[];
 
   if (args.tracked) {
@@ -1011,6 +1264,8 @@ async function commandList(registry: DiscordChannelRegistry, args: CliArgs): Pro
     if (!args.json) console.log("\n All Channels\n");
     channels = await registry.getAllChannels();
   }
+
+  channels = sortChannelsForDisplay(channels);
 
   if (channels.length === 0) {
     if (args.json) {
@@ -1134,31 +1389,144 @@ async function commandShow(registry: DiscordChannelRegistry, channelId: string):
 // Command: stats
 // ============================================================================
 
-async function commandStats(registry: DiscordChannelRegistry, args: CliArgs): Promise<void> {
+async function commandStats(registry: DiscordChannelRegistry, args: CliArgs, db: Database): Promise<void> {
   const stats = await registry.getStats();
   if (args.json) {
     outputJson({ ok: true, command: "channels.stats", data: stats });
     return;
   }
+
+  // Fetch richer coverage stats directly from items table
+  const coverageRow = await db.get<{
+    total_records: number; days_with_msgs: number; empty_records: number;
+    total_msgs: number; earliest: string; latest: string;
+  }>(`
+    SELECT
+      COUNT(*)                                                                  AS total_records,
+      SUM(CASE WHEN CAST(json_extract(metadata,'$.messageCount') AS INTEGER) > 0 THEN 1 ELSE 0 END) AS days_with_msgs,
+      SUM(CASE WHEN json_extract(metadata,'$.empty') = 1 THEN 1 ELSE 0 END)   AS empty_records,
+      SUM(CAST(json_extract(metadata,'$.messageCount') AS INTEGER))            AS total_msgs,
+      date(MIN(date),'unixepoch')                                              AS earliest,
+      date(MAX(date),'unixepoch')                                              AS latest
+    FROM items WHERE type='discordRawData'`);
+
+  // Channels with real messages in last 30 / 90 days
+  const t30 = Math.floor(Date.now() / 1000) - 30 * 86400;
+  const t90 = Math.floor(Date.now() / 1000) - 90 * 86400;
+  const recentActivity = await db.all<Array<{ ch: string; name: string; msgs_30d: number; msgs_90d: number; last_msg: string }>>(`
+    SELECT
+      substr(i.cid, 13, length(i.cid) - 23)                                     AS ch,
+      c.name,
+      SUM(CASE WHEN i.date >= ${t30} THEN CAST(json_extract(i.metadata,'$.messageCount') AS INTEGER) ELSE 0 END) AS msgs_30d,
+      SUM(CASE WHEN i.date >= ${t90} THEN CAST(json_extract(i.metadata,'$.messageCount') AS INTEGER) ELSE 0 END) AS msgs_90d,
+      date(MAX(CASE WHEN CAST(json_extract(i.metadata,'$.messageCount') AS INTEGER) > 0 THEN i.date ELSE 0 END),'unixepoch') AS last_msg
+    FROM items i
+    JOIN discord_channels c ON c.id = substr(i.cid, 13, length(i.cid) - 23)
+    WHERE i.type='discordRawData' AND c.unavailableReason IS NULL
+    GROUP BY ch
+    HAVING msgs_90d > 0
+    ORDER BY msgs_30d DESC`);
+
+  const unavailableCount = await db.get<{ count: number }>(
+    "SELECT COUNT(*) as count FROM discord_channels WHERE unavailableReason IS NOT NULL"
+  );
+  const unavailableByReason = await db.all<Array<{ reason: string; count: number }>>(
+    `SELECT unavailableReason as reason, COUNT(*) as count
+     FROM discord_channels
+     WHERE unavailableReason IS NOT NULL
+     GROUP BY unavailableReason
+     ORDER BY count DESC, reason ASC`
+  );
+  const accessibleNoRowsCount = await db.get<{ count: number }>(
+    `SELECT COUNT(*) as count
+     FROM discord_channels c
+     WHERE c.unavailableReason IS NULL
+       AND NOT EXISTS (
+         SELECT 1 FROM items i
+         WHERE i.type = 'discordRawData'
+           AND substr(i.cid, 13, length(i.cid) - 23) = c.id
+       )`
+  );
+  const accessibleNoRows = await db.all<Array<{ name: string; categoryName: string | null }>>(
+    `SELECT c.name, c.categoryName
+     FROM discord_channels c
+     WHERE c.unavailableReason IS NULL
+       AND NOT EXISTS (
+         SELECT 1 FROM items i
+         WHERE i.type = 'discordRawData'
+           AND substr(i.cid, 13, length(i.cid) - 23) = c.id
+       )
+     ORDER BY c.categoryName, c.name
+     LIMIT 10`
+  );
+  const staleCoverageCount = await db.get<{ count: number }>(
+    `SELECT COUNT(*) as count
+     FROM discord_channels c
+     WHERE c.unavailableReason IS NULL
+       AND EXISTS (
+         SELECT 1 FROM items i
+         WHERE i.type = 'discordRawData'
+           AND substr(i.cid, 13, length(i.cid) - 23) = c.id
+       )
+       AND COALESCE((
+         SELECT MAX(i.date)
+         FROM items i
+         WHERE i.type = 'discordRawData'
+           AND substr(i.cid, 13, length(i.cid) - 23) = c.id
+       ), 0) < ?`,
+    t90
+  );
+
+  const totalRecords = coverageRow?.total_records ?? 0;
+  const daysWithMessages = coverageRow?.days_with_msgs ?? 0;
+  const emptyRecords = coverageRow?.empty_records ?? 0;
+  const totalMessages = coverageRow?.total_msgs ?? 0;
+  const pct = totalRecords > 0 ? Math.round(100 * daysWithMessages / totalRecords) : 0;
+  const unavailable = unavailableCount?.count || 0;
+
   console.log("\n Channel Registry Statistics\n");
 
-  console.log(`Channels: ${stats.totalChannels} total, ${stats.trackedChannels} tracked, ${stats.mutedChannels} muted`);
-  console.log(`Guilds: ${stats.totalGuilds}`);
-  console.log(`Total messages: ${stats.totalMessages.toLocaleString()}`);
+  console.log(`Channels: ${stats.totalChannels} total, ${stats.trackedChannels} tracked, ${stats.mutedChannels} muted, ${unavailable} unavailable`);
+  console.log(`Coverage: ${coverageRow?.earliest ?? '?'} → ${coverageRow?.latest ?? '?'}`);
+  console.log(`Records:  ${totalRecords.toLocaleString()} total  |  ${daysWithMessages.toLocaleString()} with messages (${pct}%)  |  ${emptyRecords.toLocaleString()} empty`);
+  console.log(`Messages: ${totalMessages.toLocaleString()} across all time`);
+  console.log(`Gaps:     ${(accessibleNoRowsCount?.count ?? 0).toLocaleString()} accessible channels with no raw rows  |  ${(staleCoverageCount?.count ?? 0).toLocaleString()} with no coverage in last 90 days`);
 
-  console.log(`\nActivity Distribution:`);
-  console.log(`   Hot (>50 msgs/day): ${stats.hotChannels}`);
-  console.log(`   Active (7-50): ${stats.activeChannels}`);
-  console.log(`   Moderate (1.5-7): ${stats.moderateChannels}`);
-  console.log(`   Quiet (<1.5): ${stats.quietChannels}`);
+  console.log(`\nActivity Distribution (7-day rolling velocity, accessible channels):`);
+  console.log(`   Hot     (>50 msgs/day):  ${stats.hotChannels}`);
+  console.log(`   Active  (7–50):          ${stats.activeChannels}`);
+  console.log(`   Moderate(1.5–7):         ${stats.moderateChannels}`);
+  console.log(`   Quiet   (<1.5):          ${stats.quietChannels}`);
 
-  console.log(`\nChanges Tracked:`);
-  console.log(`   Name changes: ${stats.channelsWithNameChanges} channels`);
-  console.log(`   Topic changes: ${stats.channelsWithTopicChanges} channels`);
-  console.log(`   Category changes: ${stats.channelsWithCategoryChanges} channels`);
+  if (unavailableByReason.length > 0) {
+    console.log(`\nUnavailable by reason:`);
+    for (const row of unavailableByReason) {
+      console.log(`   ${row.reason}: ${row.count}`);
+    }
+  }
 
-  if (stats.mostActiveChannel) {
-    console.log(`\nMost Active: #${stats.mostActiveChannel.name} (${stats.mostActiveChannel.velocity.toFixed(1)} msgs/day)`);
+  if (accessibleNoRows.length > 0) {
+    console.log(`\nAccessible channels with no raw rows (${accessibleNoRowsCount?.count ?? 0} total):`);
+    for (const row of accessibleNoRows) {
+      const category = row.categoryName ? ` [${row.categoryName}]` : "";
+      console.log(`   #${row.name}${category}`);
+    }
+    if ((accessibleNoRowsCount?.count || 0) > accessibleNoRows.length) {
+      console.log(`   ... and ${(accessibleNoRowsCount?.count || 0) - accessibleNoRows.length} more`);
+    }
+  }
+
+  if (recentActivity.length > 0) {
+    console.log(`\nChannels with messages in last 90 days (${recentActivity.length} total):`);
+    const fmt = (n: number) => n.toString().padStart(6);
+    console.log(`   ${'Channel'.padEnd(28)} ${'30d'.padStart(6)} ${'90d'.padStart(6)}  Last message`);
+    console.log(`   ${'-'.repeat(28)} ${'-'.repeat(6)} ${'-'.repeat(6)}  ${'-'.repeat(12)}`);
+    for (const r of recentActivity.slice(0, 20)) {
+      console.log(`   #${r.name.padEnd(27)} ${fmt(r.msgs_30d)} ${fmt(r.msgs_90d)}  ${r.last_msg}`);
+    }
+    if (recentActivity.length > 20) console.log(`   ... and ${recentActivity.length - 20} more`);
+  } else {
+    console.log(`\nNo channels with messages in last 90 days.`);
   }
 
   console.log("");
@@ -1191,7 +1559,7 @@ async function commandMute(registry: DiscordChannelRegistry, channelId: string, 
   }
 
   await registry.setMuted(channelId, muted);
-  console.log(`\nChannel #${channel.name} is now ${muted ? "muted" : "unmuted"}\n`);
+  console.log(`\nChannel #${channel.name} is now ${muted ? "ignored in summaries" : "included in summaries"}\n`);
 }
 
 // ============================================================================
@@ -1328,6 +1696,33 @@ async function commandBuildRegistry(db: Database, args: CliArgs): Promise<void> 
 }
 
 // ============================================================================
+// Command: fix-states (one-time migration)
+// ============================================================================
+
+async function commandFixStates(registry: DiscordChannelRegistry, args: CliArgs): Promise<void> {
+  const allChannels = await registry.getAllChannels();
+  // Heuristic: isMuted=1 AND isTracked=0 = auto-muted by discover (not user-intentional)
+  const autoMuted = allChannels.filter(c => c.isMuted && !c.isTracked);
+
+  console.log(`Found ${autoMuted.length} auto-muted channels to migrate to unavailable state`);
+  if (args.dryRun) {
+    const preview = autoMuted.slice(0, 20);
+    for (const ch of preview) {
+      console.log(`  ${ch.id} #${ch.name}`);
+    }
+    if (autoMuted.length > 20) console.log(`  ... and ${autoMuted.length - 20} more`);
+    console.log("\n(dry run — no changes made)");
+    return;
+  }
+
+  for (const ch of autoMuted) {
+    await registry.markUnavailable(ch.id, ch.unavailableReason || "Channel inaccessible (migrated from muted)");
+    await registry.setMuted(ch.id, false);
+  }
+  console.log(`Migrated ${autoMuted.length} channels. isMuted is now reserved for user-driven mutes only.`);
+}
+
+// ============================================================================
 // Command: help
 // ============================================================================
 
@@ -1348,47 +1743,323 @@ async function commandResetUnavailable(registry: DiscordChannelRegistry, args: C
   console.log(`\nCleared unavailability status for ${cleared} channel(s).`);
 }
 
+// ============================================================================
+// Command: sync (discover → analyze → propose pipeline, optionally with mirror)
+// ============================================================================
+
+async function commandSync(db: Database, registry: DiscordChannelRegistry, args: CliArgs): Promise<void> {
+  if (args.withFetch) {
+    console.log("\n=== Step 1/4: Discover ===");
+    try {
+      await commandDiscover(db, args);
+    } catch (e) {
+      console.warn("Discover failed, continuing:", e);
+    }
+
+    console.log("\n=== Step 2/4: Mirror ===");
+    await commandMirror(db, registry, args);
+
+    console.log("\n=== Step 3/4: Analyze ===");
+    await commandAnalyze(db, registry, { ...args, all: true });
+
+    console.log("\n=== Step 4/4: Propose ===");
+    await commandProposeUpdate(db, registry, args);
+  } else {
+    console.log("\n=== Step 1/3: Discover ===");
+    try {
+      await commandDiscover(db, args);
+    } catch (e) {
+      console.warn("Discover failed, continuing:", e);
+    }
+
+    console.log("\n=== Step 2/3: Analyze ===");
+    await commandAnalyze(db, registry, { ...args, all: true });
+
+    console.log("\n=== Step 3/3: Propose ===");
+    await commandProposeUpdate(db, registry, args);
+  }
+
+  if (args.apply) {
+    console.log("\nDone. Config updated automatically (--apply).");
+  } else {
+    console.log("\nDone. Review the proposal above and edit your config channelIds.");
+    console.log("Tip: use --apply to write changes to config automatically.");
+  }
+}
+
+/** @deprecated Use `channels sync --with-fetch` instead */
+async function commandRefresh(db: Database, registry: DiscordChannelRegistry, args: CliArgs): Promise<void> {
+  console.warn("⚠ 'channels refresh' is deprecated. Use 'channels sync --with-fetch' instead.");
+  await commandSync(db, registry, { ...args, withFetch: true });
+}
+
+/** @deprecated Use `channels sync` instead */
+async function commandUpdate(db: Database, registry: DiscordChannelRegistry, args: CliArgs): Promise<void> {
+  console.warn("⚠ 'channels update' is deprecated. Use 'channels sync' instead.");
+  await commandSync(db, registry, args);
+}
+
+// ============================================================================
+// Command: mirror (fetch raw messages from ALL accessible channels → DB)
+// ============================================================================
+
+async function commandMirror(db: Database, registry: DiscordChannelRegistry, args: CliArgs): Promise<void> {
+  const configs = loadConfigs(args.source);
+  const guildIds = getGuildIds(configs);
+  const trackedChannels = getTrackedChannelIds(configs);
+  let allChannels = filterChannelsByGuildIds(await registry.getAllChannels(), guildIds);
+
+  if (allChannels.length === 0) {
+    console.log("No channels found in registry for this source. Run 'channels discover' first.");
+    return;
+  }
+
+  const unavailableBefore = allChannels.filter(c => c.unavailableReason);
+  let revalidated = 0;
+
+  if (unavailableBefore.length > 0) {
+    if (args.dryRun) {
+      console.log(`\nWould revalidate ${unavailableBefore.length} unavailable channels before mirroring.`);
+    } else {
+      const tokenInfo = resolveDiscordBotToken(configs);
+      if (!tokenInfo.token) {
+        console.log(`\nSkipping unavailable-channel revalidation for ${unavailableBefore.length} channels (no Discord token available).`);
+      } else {
+        console.log(`\nRevalidating ${unavailableBefore.length} unavailable channels before mirroring...`);
+        const client = new Client({ intents: [GatewayIntentBits.Guilds] });
+        const observedAt = new Date().toISOString().split("T")[0];
+        try {
+          await client.login(tokenInfo.token);
+          for (const channel of unavailableBefore) {
+            try {
+              const fetched = await client.channels.fetch(channel.id);
+              if (!fetched || !isSupportedSyncChannel(fetched)) {
+                continue;
+              }
+
+              await upsertRegistryChannelFromDiscord(
+                registry,
+                fetched,
+                observedAt,
+                trackedChannels.get(channel.guildId)?.has(channel.id) || channel.isTracked
+              );
+              await registry.clearUnavailable(channel.id);
+              revalidated++;
+            } catch (error: any) {
+              if (args.debug) {
+                console.error(`  Revalidation failed for ${channel.id}: ${error.message}`);
+              }
+            }
+          }
+        } finally {
+          await client.destroy();
+        }
+
+        if (revalidated > 0) {
+          allChannels = filterChannelsByGuildIds(await registry.getAllChannels(), guildIds);
+          console.log(`Revalidated ${revalidated}/${unavailableBefore.length} previously unavailable channels.`);
+        } else {
+          console.log("No unavailable channels were revalidated.");
+        }
+      }
+    }
+  }
+
+  const accessible = allChannels.filter(c => !c.unavailableReason);
+
+  if (accessible.length === 0) {
+    console.log("No accessible channels in registry after revalidation. Run 'channels discover' first or check bot permissions.");
+    return;
+  }
+
+  // Auto-detect date range from channel creation timestamps if not specified
+  const after = args.after ?? (() => {
+    const earliest = accessible.reduce((min, c) => c.createdAt > 0 && c.createdAt < min ? c.createdAt : min, Infinity);
+    return earliest === Infinity ? "2015-01-01" : new Date(earliest * 1000).toISOString().split("T")[0];
+  })();
+  const before = args.before ?? new Date().toISOString().split("T")[0];
+
+  const channelIds = accessible.map(c => c.id).join(",");
+
+  console.log(`\nMirroring ${accessible.length} accessible channels (${allChannels.length - accessible.length} unavailable skipped${revalidated > 0 ? `, ${revalidated} revalidated` : ""})`);
+  console.log(`Date range: ${after} → ${before}${!args.after ? " (auto-detected from channel creation dates)" : ""}`);
+
+  // Show breakdown by category
+  const byCategory = new Map<string, number>();
+  for (const ch of accessible) {
+    const cat = ch.categoryName || "Uncategorized";
+    byCategory.set(cat, (byCategory.get(cat) || 0) + 1);
+  }
+  for (const [cat, count] of [...byCategory.entries()].sort((a, b) => b[1] - a[1]).slice(0, 8)) {
+    console.log(`  ${cat}: ${count} channels`);
+  }
+  if (byCategory.size > 8) console.log(`  ... and ${byCategory.size - 8} more categories`);
+
+  const sourceFlag = args.source ? ` --source=${args.source}` : "";
+  const cmd = `npm run historical -- --after=${after} --before=${before} --onlyFetch --channels=<${accessible.length} channel IDs>${sourceFlag}`;
+  console.log(`\nWill run: ${cmd}`);
+
+  if (args.dryRun) {
+    console.log("(dry run — skipping execution)");
+    return;
+  }
+
+  const { spawn } = await import("child_process");
+  const spawnArgs = [
+    "-r", "tsconfig-paths/register", "--transpile-only", "src/historical.ts",
+    `--after=${after}`, `--before=${before}`, "--onlyFetch",
+    `--channels=${channelIds}`,
+  ];
+  if (args.source) spawnArgs.push(`--source=${args.source}`);
+
+  console.log(`\nStarting fetch (this may take a while for large ranges)...`);
+  const child = spawn("ts-node", spawnArgs, { stdio: "inherit", shell: true, cwd: process.cwd() });
+  await new Promise<void>((resolve, reject) => {
+    child.on("close", (code: number | null) =>
+      code === 0 || code === null ? resolve() : reject(new Error(`Exit code ${code}`))
+    );
+  });
+
+  console.log("\nSyncing channel registry stats from fetched data...");
+  const { updated } = await registry.syncStats();
+  console.log(`Updated stats for ${updated} channels.`);
+}
+
+// ============================================================================
+// Command: archive (generate summaries from existing DB data)
+// ============================================================================
+
+async function commandArchive(db: Database, registry: DiscordChannelRegistry, args: CliArgs): Promise<void> {
+  if (!args.after || !args.before) {
+    console.error("Error: --after and --before are required");
+    console.log("Usage: npm run channels -- archive --after=YYYY-MM-DD --before=YYYY-MM-DD [--source=...] [--output=...]");
+    return;
+  }
+
+  const afterTs = Math.floor(new Date(args.after).getTime() / 1000);
+  const beforeTs = Math.floor(new Date(args.before + "T23:59:59Z").getTime() / 1000);
+
+  // Per-date stats
+  const dateCounts = await db.all<Array<{ date: number; cnt: number }>>(
+    `SELECT date, COUNT(*) as cnt FROM items
+     WHERE type='discordRawData' AND date >= ? AND date <= ?
+     GROUP BY date ORDER BY date`,
+    afterTs, beforeTs
+  );
+
+  if (dateCounts.length === 0) {
+    console.log(`No raw data in DB for ${args.after} → ${args.before}.`);
+    console.log("Hint: channels must have been fetched during this period.");
+    return;
+  }
+
+  // Check already-summarized dates
+  const existingSummaries = await db.all<Array<{ date: number }>>(
+    `SELECT DISTINCT date FROM items WHERE type LIKE '%Summary%' AND date >= ? AND date <= ?`,
+    afterTs, beforeTs
+  );
+  const summarizedDates = new Set(existingSummaries.map(r => r.date));
+  const toGenerate = dateCounts.filter(r => args.force || !summarizedDates.has(r.date));
+
+  const firstDate = new Date(dateCounts[0].date * 1000).toISOString().split('T')[0];
+  const lastDate = new Date(dateCounts[dateCounts.length - 1].date * 1000).toISOString().split('T')[0];
+
+  console.log(`\nFound data in ${firstDate} → ${lastDate}:`);
+  console.log(`  Total dates with raw data:  ${dateCounts.length}`);
+  console.log(`  Already summarized:         ${summarizedDates.size}  (use -f to force regenerate)`);
+  console.log(`  ──────────────────────────────────`);
+  console.log(`  Dates to generate:          ${toGenerate.length}  (~${toGenerate.length} LLM calls)`);
+
+  const sourceFlag = args.source ? ` --source=${args.source}` : "";
+  const outputFlag = args.output ? ` --output=${args.output}` : "";
+  const forceFlag = args.force ? " --force" : " --skip-existing";
+  const cmd = `npm run historical -- --after=${args.after} --before=${args.before} --onlyGenerate${forceFlag}${sourceFlag}${outputFlag}`;
+  console.log(`\nWill run: ${cmd}`);
+
+  if (args.dryRun) {
+    console.log("(dry run — skipping execution)");
+    return;
+  }
+
+  const { spawn } = await import("child_process");
+  const spawnArgs = [
+    "-r", "tsconfig-paths/register", "--transpile-only", "src/historical.ts",
+    `--after=${args.after}`, `--before=${args.before}`, "--onlyGenerate",
+  ];
+  if (args.source) spawnArgs.push(`--source=${args.source}`);
+  if (args.output) spawnArgs.push(`--output=${args.output}`);
+  if (!args.force) spawnArgs.push("--skip-existing");
+  else spawnArgs.push("--force");
+
+  const child = spawn("ts-node", spawnArgs, { stdio: "inherit", shell: true, cwd: process.cwd() });
+  await new Promise<void>((resolve, reject) => {
+    child.on("close", (code: number | null) =>
+      code === 0 || code === null ? resolve() : reject(new Error(`Exit code ${code}`))
+    );
+  });
+}
+
 function commandHelp(): void {
   console.log(`
 Discord Channel Management CLI
 
+Pipeline Commands:
+  sync [--source=<config>.json] [--dry-run] [--apply]            Run discover → analyze → propose in one step
+  sync --with-fetch [--after=YYYY-MM-DD] [--before=YYYY-MM-DD]   Full pipeline: discover → mirror → analyze → propose
+       [--source=<config>.json] [--dry-run] [--apply]
+
 Discovery & Analysis:
-  discover [--source=<config>.json]       Fetch channels from Discord (or raw data if no token)
-  analyze [--all] [--channel=ID]          Run LLM analysis on channels
-  summarize [--all] [--channel=ID]        Generate AI summaries and mannerism guides
-  propose [--dry-run]                     Generate config diff and PR markdown
+  discover [--source=<config>.json]                              Fetch channels from Discord (or raw data if no token)
+  analyze [--all] [--channel=ID]                                 Run LLM analysis on channels
+  propose [--dry-run] [--apply]                                  Generate config diff and PR markdown; --apply writes changes to config
+  mirror  [--after=YYYY-MM-DD] [--before=YYYY-MM-DD]             Fetch raw messages from registry channels → DB
+          [--source=<config>.json] [--dry-run]                  (date range auto-detected from channel creation dates)
+  archive --after=YYYY-MM-DD --before=YYYY-MM-DD                Generate summaries from historical DB activity for each day
+          [--source=<config>.json] [--output=<path>] [--dry-run] [-f/--force]
 
 Query Commands:
   list [--tracked|--active|--muted|--quiet]   List channels with optional filters
+  list --interactive --source=<config>.json   Interactively track/untrack and ignore noisy channels
   show <channelId>                            Show detailed channel info
-  stats                                       Show channel registry statistics
+  stats                                       Show channel registry, access, and coverage statistics
 
 Management Commands:
   track <channelId>                       Mark channel as tracked
   untrack <channelId>                     Mark channel as not tracked
-  mute <channelId>                        Mute channel (hide from recommendations)
-  unmute <channelId>                      Unmute channel
+  mute <channelId>                        Ignore channel in summaries and recommendations
+  unmute <channelId>                      Include channel in summaries again
 
 Registry Commands:
   build-registry [--dry-run]              Backfill discord_channels from discordRawData
   reset-unavailable                       Clear unavailability status for all channels
+  fix-states [--dry-run]                  Migrate auto-muted channels to unavailable state (one-time)
 
-Options:
+  Options:
   --source=<config>.json                  Filter to a single config file (e.g. --source=m3org.json)
+  --output=<path>                         Output directory for generated summary files
+  --interactive                           Launch terminal selector for track/untrack and ignore toggles
   --json                                  Output machine-readable JSON for query commands
+  Env: CHANNEL_ANALYZE_MODEL              Override the LLM model used by 'analyze'
+
+  Deprecated (still work, use sync instead):
+  update [--source=<config>.json]         Alias for 'sync'
+  refresh [--after/--before]             Alias for 'sync --with-fetch'
 
 Examples:
-  npm run channels -- discover              # Discover channels (Discord API or raw data)
+  npm run channels -- sync --source=m3org.json                    # Full discover→analyze→propose pipeline
+  npm run channels -- sync --with-fetch --source=m3org.json       # Full pipeline including mirror
+  npm run channels -- archive --after=2025-10-01 --before=2025-12-01 --source=m3org.json --dry-run  # Preview backfill
+  npm run channels -- archive --after=2025-10-01 --before=2025-12-01 --source=m3org.json --output=./output/m3org  # Backfill summaries
   npm run channels -- discover --source=m3org.json  # Discover for a specific config
   npm run channels -- analyze               # Analyze channels needing analysis
   npm run channels -- analyze --all         # Re-analyze all channels
   npm run channels -- analyze --channel=123 # Analyze a single channel
-  npm run channels -- summarize             # Summarize unsummarized channels
-  npm run channels -- summarize --all       # Re-summarize all active channels
   npm run channels -- propose               # Generate PR body with config changes
   npm run channels -- list --tracked        # List tracked channels
+  npm run channels -- list --interactive --source=m3org.json   # Pick tracked channels and ignore noisy ones
 
-Workflow (automated via GitHub Action):
+Workflow (run individually or all at once with 'sync'):
+  npm run channels -- sync --source=m3org.json     # One-shot pipeline
   1. npm run channels -- discover            # Fetch channels
   2. npm run channels -- analyze             # Run LLM analysis
   3. npm run channels -- propose             # Generate PR body
@@ -1401,6 +2072,434 @@ Workflow (automated via GitHub Action):
 
 function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function compareNullableStrings(a?: string | null, b?: string | null): number {
+  if (!a && !b) return 0;
+  if (!a) return 1;
+  if (!b) return -1;
+  return a.localeCompare(b);
+}
+
+function sortChannelsForDisplay(channels: DiscordChannel[]): DiscordChannel[] {
+  const guildOrder = new Map<string, number>();
+  const categoryOrder = new Map<string, number>();
+
+  const byGuild = new Map<string, DiscordChannel[]>();
+  for (const channel of channels) {
+    const guildKey = `${channel.guildId}|${channel.guildName || ""}`;
+    if (!byGuild.has(guildKey)) {
+      byGuild.set(guildKey, []);
+    }
+    byGuild.get(guildKey)!.push(channel);
+  }
+
+  const guildKeys = Array.from(byGuild.keys()).sort((a, b) => {
+    const aName = a.split("|")[1] || "";
+    const bName = b.split("|")[1] || "";
+    return aName.localeCompare(bName);
+  });
+
+  guildKeys.forEach((guildKey, guildIndex) => {
+    guildOrder.set(guildKey, guildIndex);
+    const categoryMinPos = new Map<string, number>();
+    for (const channel of byGuild.get(guildKey) || []) {
+      const categoryKey = `${guildKey}|${channel.categoryId || "uncategorized"}|${channel.categoryName || ""}`;
+      const current = categoryMinPos.get(categoryKey);
+      const pos = channel.position ?? Number.MAX_SAFE_INTEGER;
+      if (current === undefined || pos < current) {
+        categoryMinPos.set(categoryKey, pos);
+      }
+    }
+
+    Array.from(categoryMinPos.entries())
+      .sort((a, b) => {
+        if (a[1] !== b[1]) return a[1] - b[1];
+        return a[0].localeCompare(b[0]);
+      })
+      .forEach(([categoryKey], categoryIndex) => {
+        categoryOrder.set(categoryKey, categoryIndex);
+      });
+  });
+
+  return [...channels].sort((a, b) => {
+    const aGuildKey = `${a.guildId}|${a.guildName || ""}`;
+    const bGuildKey = `${b.guildId}|${b.guildName || ""}`;
+    const aCategoryKey = `${aGuildKey}|${a.categoryId || "uncategorized"}|${a.categoryName || ""}`;
+    const bCategoryKey = `${bGuildKey}|${b.categoryId || "uncategorized"}|${b.categoryName || ""}`;
+
+    const guildCmp = (guildOrder.get(aGuildKey) ?? 0) - (guildOrder.get(bGuildKey) ?? 0);
+    if (guildCmp !== 0) return guildCmp;
+
+    const categoryCmp = (categoryOrder.get(aCategoryKey) ?? 0) - (categoryOrder.get(bCategoryKey) ?? 0);
+    if (categoryCmp !== 0) return categoryCmp;
+
+    const positionCmp = (a.position ?? Number.MAX_SAFE_INTEGER) - (b.position ?? Number.MAX_SAFE_INTEGER);
+    if (positionCmp !== 0) return positionCmp;
+
+    return compareNullableStrings(a.name, b.name);
+  });
+}
+
+function ensureConfigBackup(configPath: string): void {
+  if (!fs.existsSync(BACKUP_DIR)) {
+    fs.mkdirSync(BACKUP_DIR, { recursive: true });
+  }
+  const ts = new Date().toISOString().replace(/[:.]/g, "-");
+  const backupPath = path.join(BACKUP_DIR, `${path.basename(configPath, ".json")}.${ts}.json`);
+  fs.copyFileSync(configPath, backupPath);
+}
+
+async function promptLine(prompt: string): Promise<string> {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    return await new Promise<string>(resolve => rl.question(prompt, resolve));
+  } finally {
+    rl.close();
+  }
+}
+
+async function applyTrackedSelectionToConfigs(
+  configs: Map<string, LoadedConfig>,
+  orderedTrackedIds: string[],
+  registryChannels: DiscordChannel[]
+): Promise<{ updatedConfigs: string[]; totalTracked: number }> {
+  const channelById = new Map(registryChannels.map(channel => [channel.id, channel]));
+  const updatedConfigs: string[] = [];
+
+  for (const [, configData] of configs) {
+    let modified = false;
+
+    for (const source of configData.discordSources) {
+      const resolvedGuildId = resolveConfigEnvValue(source.params?.guildId);
+      const nextIds = orderedTrackedIds.filter(channelId => {
+        const channel = channelById.get(channelId);
+        return channel && (!resolvedGuildId || channel.guildId === resolvedGuildId);
+      });
+
+      const prevIds = source.params?.channelIds || [];
+      if (JSON.stringify(prevIds) !== JSON.stringify(nextIds)) {
+        source.params.channelIds = nextIds;
+        modified = true;
+      }
+    }
+
+    if (modified) {
+      ensureConfigBackup(configData.path);
+      fs.writeFileSync(configData.path, JSON.stringify(configData.config, null, 2) + "\n");
+      updatedConfigs.push(path.basename(configData.path));
+    }
+  }
+
+  return { updatedConfigs, totalTracked: orderedTrackedIds.length };
+}
+
+async function commandInteractiveTrackSelection(
+  registry: DiscordChannelRegistry,
+  args: CliArgs
+): Promise<void> {
+  if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    console.error("\nInteractive mode requires a TTY.\n");
+    return;
+  }
+
+  if (!args.source) {
+    console.error("\nInteractive mode requires --source=<config>.json so edits apply to one config.\n");
+    return;
+  }
+
+  const configs = loadConfigs(args.source);
+  if (configs.size !== 1) {
+    console.error(`\nExpected exactly one config for --source=${args.source}, found ${configs.size}.\n`);
+    return;
+  }
+
+  const guildIds = getGuildIds(configs);
+  const allChannels = sortChannelsForDisplay(
+    (await registry.getAllChannels()).filter(channel => guildIds.size === 0 || guildIds.has(channel.guildId))
+  );
+
+  if (allChannels.length === 0) {
+    console.log("\nNo channels found in the registry for this source. Run 'channels discover' first.\n");
+    return;
+  }
+
+  const trackedByGuild = getTrackedChannelIds(configs);
+  const selected = new Set(
+    allChannels
+      .filter(channel => trackedByGuild.get(channel.guildId)?.has(channel.id))
+      .map(channel => channel.id)
+  );
+  const original = new Set(selected);
+  const ignored = new Set(allChannels.filter(channel => channel.isMuted).map(channel => channel.id));
+  const originalIgnored = new Set(ignored);
+  let filter = "";
+  let cursor = 0;
+  let message = "Use hotkeys below to edit channel state.";
+  let pendingQuitConfirmation = false;
+
+  const hasUnsavedChanges = () =>
+    allChannels.some(channel =>
+      original.has(channel.id) !== selected.has(channel.id) ||
+      originalIgnored.has(channel.id) !== ignored.has(channel.id)
+    );
+
+  const getVisible = () => allChannels.filter(channel => {
+    if (!filter) return true;
+    const haystack = [
+      channel.name,
+      channel.categoryName || "",
+      channel.guildName || "",
+      channel.topic || "",
+    ].join(" ").toLowerCase();
+    return haystack.includes(filter.toLowerCase());
+  });
+
+  const render = () => {
+    const visible = getVisible();
+    const rows = Math.max(8, (process.stdout.rows || 24) - 8);
+    if (cursor >= visible.length) cursor = Math.max(0, visible.length - 1);
+    const start = Math.max(0, Math.min(cursor - Math.floor(rows / 2), Math.max(0, visible.length - rows)));
+    const page = visible.slice(start, start + rows);
+    const unsaved = hasUnsavedChanges();
+
+    console.clear();
+    console.log(`Channel Selector: ${args.source}`);
+    console.log(`Tracked: ${selected.size}/${allChannels.length} | Ignored: ${ignored.size} | Matching: ${visible.length} | Filter: ${filter || "(none)"} | ${unsaved ? "UNSAVED CHANGES" : "saved"}`);
+    console.log("Hotkeys: ↑/↓ move  SPACE track  M ignore  / filter  C clear  S save  Q quit");
+    console.log("Legend:  [x]=tracked  [i]=ignored  [!]=no access");
+    console.log(message);
+    console.log("");
+
+    if (visible.length === 0) {
+      console.log("No channels match the current filter.");
+      return;
+    }
+
+    let lastGuild = "";
+    let lastCategory = "";
+    page.forEach((channel, index) => {
+      const absoluteIndex = start + index;
+      const guildName = channel.guildName || "Unknown Guild";
+      const categoryName = channel.categoryName || "No Category";
+      if (guildName !== lastGuild) {
+        console.log(`${guildName}`);
+        lastGuild = guildName;
+        lastCategory = "";
+      }
+      if (categoryName !== lastCategory) {
+        console.log(`  [${categoryName}]`);
+        lastCategory = categoryName;
+      }
+
+      const pointer = absoluteIndex === cursor ? ">" : " ";
+      const tracked = selected.has(channel.id) ? "x" : " ";
+      const ignoredMarker = ignored.has(channel.id) ? "i" : " ";
+      const unavailable = channel.unavailableReason ? "!" : " ";
+      const velocity = `${channel.currentVelocity.toFixed(1)}`.padStart(5);
+      console.log(` ${pointer} [${tracked}][${ignoredMarker}][${unavailable}] #${channel.name.padEnd(28)} ${velocity} msg/day  ${channel.id}`);
+    });
+  };
+
+  await new Promise<void>((resolve) => {
+    readline.emitKeypressEvents(process.stdin);
+    process.stdin.resume();
+    if (process.stdin.isTTY) {
+      process.stdin.setRawMode(true);
+    }
+
+    const cleanup = () => {
+      process.stdin.off("keypress", onKeypress);
+      if (process.stdin.isTTY) {
+        process.stdin.setRawMode(false);
+      }
+      process.stdin.pause();
+      console.clear();
+      resolve();
+    };
+
+    const save = async () => {
+      const orderedTrackedIds = allChannels.filter(channel => selected.has(channel.id)).map(channel => channel.id);
+      const changedTrackIds = allChannels
+        .filter(channel => original.has(channel.id) !== selected.has(channel.id))
+        .map(channel => channel.id);
+      const changedIgnoredIds = allChannels
+        .filter(channel => originalIgnored.has(channel.id) !== ignored.has(channel.id))
+        .map(channel => channel.id);
+
+      if (changedTrackIds.length === 0 && changedIgnoredIds.length === 0) {
+        message = "No changes to save.";
+        pendingQuitConfirmation = false;
+        render();
+        cleanup();
+        return;
+      }
+
+      let updatedConfigs: string[] = [];
+      let totalTracked = selected.size;
+      if (changedTrackIds.length > 0) {
+        const configUpdate = await applyTrackedSelectionToConfigs(configs, orderedTrackedIds, allChannels);
+        updatedConfigs = configUpdate.updatedConfigs;
+        totalTracked = configUpdate.totalTracked;
+      }
+
+      for (const channel of allChannels) {
+        const shouldTrack = selected.has(channel.id);
+        if (channel.isTracked !== shouldTrack) {
+          await registry.setTracked(channel.id, shouldTrack);
+          channel.isTracked = shouldTrack;
+        }
+        const shouldIgnore = ignored.has(channel.id);
+        if (channel.isMuted !== shouldIgnore) {
+          await registry.setMuted(channel.id, shouldIgnore);
+          channel.isMuted = shouldIgnore;
+        }
+      }
+
+      const parts: string[] = [];
+      if (updatedConfigs.length > 0) {
+        parts.push(`tracked ${totalTracked} channels in ${updatedConfigs.join(", ")}`);
+      }
+      if (changedIgnoredIds.length > 0) {
+        parts.push(`updated ignore state for ${changedIgnoredIds.length} channel(s)`);
+      }
+      message = parts.length > 0 ? `Saved: ${parts.join("; ")}.` : "Saved registry changes.";
+      pendingQuitConfirmation = false;
+      render();
+      cleanup();
+    };
+
+    const onKeypress = async (_str: string, key: readline.Key) => {
+      const visible = getVisible();
+
+      if (key.ctrl && key.name === "c") {
+        if (hasUnsavedChanges() && !pendingQuitConfirmation) {
+          pendingQuitConfirmation = true;
+          message = "Unsaved changes. Press q again to quit without saving, or press s to save.";
+          render();
+        } else {
+          message = "Cancelled.";
+          render();
+          cleanup();
+        }
+        return;
+      }
+
+      if (key.name === "up" || key.name === "k") {
+        pendingQuitConfirmation = false;
+        cursor = Math.max(0, cursor - 1);
+        render();
+        return;
+      }
+
+      if (key.name === "down" || key.name === "j") {
+        pendingQuitConfirmation = false;
+        cursor = Math.min(Math.max(0, visible.length - 1), cursor + 1);
+        render();
+        return;
+      }
+
+      if (key.name === "space") {
+        const channel = visible[cursor];
+        if (channel) {
+          if (selected.has(channel.id)) selected.delete(channel.id);
+          else selected.add(channel.id);
+          pendingQuitConfirmation = false;
+          message = `${selected.has(channel.id) ? "Tracking" : "Untracking"} #${channel.name}`;
+        }
+        render();
+        return;
+      }
+
+      if (key.name === "m") {
+        const channel = visible[cursor];
+        if (channel) {
+          if (ignored.has(channel.id)) ignored.delete(channel.id);
+          else ignored.add(channel.id);
+          pendingQuitConfirmation = false;
+          message = `${ignored.has(channel.id) ? "Ignoring" : "Including"} #${channel.name} in summaries`;
+        }
+        render();
+        return;
+      }
+
+      if (key.name === "c") {
+        filter = "";
+        cursor = 0;
+        pendingQuitConfirmation = false;
+        message = "Filter cleared.";
+        render();
+        return;
+      }
+
+      if (key.name === "q" || key.name === "escape") {
+        if (hasUnsavedChanges() && !pendingQuitConfirmation) {
+          pendingQuitConfirmation = true;
+          message = "Unsaved changes. Press q again to quit without saving, or press s to save.";
+          render();
+        } else {
+          message = hasUnsavedChanges() ? "Cancelled without saving." : "Cancelled.";
+          render();
+          cleanup();
+        }
+        return;
+      }
+
+      if (key.name === "s" || key.name === "return") {
+        pendingQuitConfirmation = false;
+        process.stdin.off("keypress", onKeypress);
+        if (process.stdin.isTTY) {
+          process.stdin.setRawMode(false);
+        }
+        process.stdin.pause();
+        try {
+          await save();
+        } catch (error: any) {
+          message = `Save failed: ${error.message}`;
+          readline.emitKeypressEvents(process.stdin);
+          process.stdin.resume();
+          if (process.stdin.isTTY) {
+            process.stdin.setRawMode(true);
+          }
+          process.stdin.on("keypress", onKeypress);
+          render();
+        }
+        return;
+      }
+
+      if (_str === "/") {
+        process.stdin.off("keypress", onKeypress);
+        if (process.stdin.isTTY) {
+          process.stdin.setRawMode(false);
+        }
+        try {
+          filter = (await promptLine("Filter channels by name/category/guild: ")).trim();
+          cursor = 0;
+          pendingQuitConfirmation = false;
+          message = filter ? `Filter applied: ${filter}` : "Filter cleared.";
+        } finally {
+          readline.emitKeypressEvents(process.stdin);
+          process.stdin.resume();
+          if (process.stdin.isTTY) {
+            process.stdin.setRawMode(true);
+          }
+          process.stdin.on("keypress", onKeypress);
+          render();
+        }
+      }
+    };
+
+    process.stdin.on("keypress", onKeypress);
+    render();
+  });
+
+  const changed = allChannels.filter(channel =>
+    original.has(channel.id) !== channel.isTracked ||
+    originalIgnored.has(channel.id) !== channel.isMuted
+  );
+  if (changed.length > 0) {
+    console.log(`Saved ${changed.length} channel state changes.\n`);
+  }
 }
 
 // ============================================================================
@@ -1429,6 +2528,27 @@ export async function runChannels(argv: string[] = process.argv.slice(2)) {
 
   try {
     switch (args.command) {
+      case "sync":
+        await commandSync(db, registry, args);
+        break;
+      case "update":
+        await commandUpdate(db, registry, args);
+        break;
+      case "refresh":
+        await commandRefresh(db, registry, args);
+        break;
+      case "mirror":
+        await commandMirror(db, registry, args);
+        break;
+      case "sync-stats": {
+        console.log("Rebuilding channel stats from items table...");
+        const { updated } = await registry.syncStats();
+        console.log(`Done — updated stats for ${updated} channels.`);
+        break;
+      }
+      case "archive":
+        await commandArchive(db, registry, args);
+        break;
       case "discover":
         await commandDiscover(db, args);
         break;
@@ -1453,7 +2573,7 @@ export async function runChannels(argv: string[] = process.argv.slice(2)) {
         }
         break;
       case "stats":
-        await commandStats(registry, args);
+        await commandStats(registry, args, db);
         break;
       case "track":
         if (!args.channelId) {
@@ -1492,6 +2612,9 @@ export async function runChannels(argv: string[] = process.argv.slice(2)) {
         break;
       case "reset-unavailable":
         await commandResetUnavailable(registry, args);
+        break;
+      case "fix-states":
+        await commandFixStates(registry, args);
         break;
       case "help":
       default:

--- a/scripts/users.ts
+++ b/scripts/users.ts
@@ -236,8 +236,143 @@ async function commandIndex(db: Database): Promise<void> {
 }
 
 // ============================================================================
-// Command: fetch-avatars
+// Command: fetch-avatars / sync-profiles
 // ============================================================================
+
+const PROFILE_FRESHNESS_SECONDS = 7 * 24 * 60 * 60;
+
+function isProfileFresh(metadata: any): boolean {
+  const fetchedAt = metadata?.profileFetchedAt;
+  if (typeof fetchedAt !== "number") return false;
+  return fetchedAt >= Math.floor(Date.now() / 1000) - PROFILE_FRESHNESS_SECONDS;
+}
+
+function buildDiscordProfileMetadata(discordUser: any): Record<string, any> {
+  const metadata: Record<string, any> = {
+    profileFetchedAt: Math.floor(Date.now() / 1000),
+    globalName: discordUser.globalName ?? null,
+    discriminator: discordUser.discriminator ?? null,
+    isBot: Boolean(discordUser.bot),
+    isSystem: Boolean(discordUser.system),
+    avatarHash: discordUser.avatar ?? null,
+    bannerHash: discordUser.banner ?? null,
+    accentColor: discordUser.accentColor ?? null,
+    flags: discordUser.flags?.bitfield?.toString?.() ?? null,
+    publicFlags: discordUser.flags?.bitfield?.toString?.() ?? null,
+    avatarDecorationData: discordUser.avatarDecorationData ?? null,
+  };
+
+  const bannerUrl = typeof discordUser.bannerURL === "function"
+    ? discordUser.bannerURL({ size: 512, extension: "png" })
+    : null;
+  if (bannerUrl) metadata.bannerUrl = bannerUrl;
+
+  if ("collectibles" in discordUser && discordUser.collectibles != null) {
+    metadata.collectibles = discordUser.collectibles;
+  }
+  if ("primaryGuild" in discordUser && discordUser.primaryGuild != null) {
+    metadata.primaryGuild = discordUser.primaryGuild;
+  }
+
+  return metadata;
+}
+
+async function commandSyncProfiles(db: Database, args: CliArgs): Promise<void> {
+  console.log("\n👤 Syncing Discord User Profiles\n");
+
+  const token = process.env.DISCORD_TOKEN;
+  if (!token) {
+    console.error("❌ Error: DISCORD_TOKEN not found in .env");
+    process.exit(1);
+  }
+
+  // Initialize registry
+  const registry = new DiscordUserRegistry(db);
+  await registry.initialize();
+
+  // Get users from discord_users table
+  const users = await db.all<Array<{ id: string; username: string; displayName: string; avatarUrl: string | null; metadata: string | null }>>(
+    `SELECT id, username, displayName, avatarUrl, metadata FROM discord_users`
+  );
+  console.log(`📖 Found ${users.length} users\n`);
+
+  // Filter users if --skip-existing flag is set
+  let usersToFetch = users;
+  if (args.skipExisting && !args.force) {
+    usersToFetch = users.filter(u => {
+      const metadata = u.metadata ? JSON.parse(u.metadata) : null;
+      return !isProfileFresh(metadata);
+    });
+    console.log(`⏭️  Skipping ${users.length - usersToFetch.length} users with fresh profiles\n`);
+  }
+
+  if (usersToFetch.length === 0) {
+    console.log("✅ All users already have fresh profiles!");
+    return;
+  }
+
+  const client = new Client({ intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMembers] });
+  await client.login(token);
+  console.log("🤖 Connected to Discord!\n");
+
+  const rateLimit = args.rateLimit || 100;
+  console.log(`🎨 Fetching current profile data (${rateLimit}ms rate limit)...`);
+  console.log(`⏳ Estimated time: ~${Math.round(usersToFetch.length * rateLimit / 1000 / 60)} minutes\n`);
+
+  let avatarCount = 0;
+  let metadataCount = 0;
+  let errorCount = 0;
+
+  for (let i = 0; i < usersToFetch.length; i++) {
+    const user = usersToFetch[i];
+
+    if (i > 0 && i % 50 === 0) {
+      console.log(`   Progress: ${i}/${usersToFetch.length} (${Math.round(i / usersToFetch.length * 100)}%)`);
+    }
+
+    try {
+      const discordUser = await client.users.fetch(user.id, { force: true });
+      const avatarUrl = discordUser.avatarURL({ size: 256, extension: 'png' }) || discordUser.defaultAvatarURL;
+      const profileMetadata = buildDiscordProfileMetadata(discordUser);
+
+      await db.run(
+        `UPDATE discord_users SET avatarUrl = ?, metadata = ?, updatedAt = ? WHERE id = ?`,
+        [avatarUrl, JSON.stringify(profileMetadata), Math.floor(Date.now() / 1000), user.id]
+      );
+
+      if (avatarUrl) avatarCount++;
+      metadataCount++;
+      await new Promise(resolve => setTimeout(resolve, rateLimit));
+    } catch (error: any) {
+      errorCount++;
+      // Calculate default avatar index based on user ID
+      const userIdBigInt = BigInt(user.id);
+      const index = Number((userIdBigInt >> 22n) % 6n);
+      const defaultUrl = `https://cdn.discordapp.com/embed/avatars/${index}.png`;
+
+      const errorMetadata = {
+        profileFetchedAt: Math.floor(Date.now() / 1000),
+        fetchError: error.message,
+      };
+      await db.run(
+        `UPDATE discord_users SET avatarUrl = ?, metadata = ?, updatedAt = ? WHERE id = ?`,
+        [defaultUrl, JSON.stringify(errorMetadata), Math.floor(Date.now() / 1000), user.id]
+      );
+
+      if (error.code !== 10013) {
+        console.warn(`   ⚠️  Failed to fetch user ${user.id}: ${error.message}`);
+      }
+      await new Promise(resolve => setTimeout(resolve, rateLimit));
+    }
+  }
+
+  await client.destroy();
+
+  console.log(`\n✅ Synced ${usersToFetch.length} user profiles:`);
+  console.log(`   - ${avatarCount} avatar URLs updated`);
+  console.log(`   - ${metadataCount} metadata records updated`);
+  if (errorCount > 0) console.log(`   - ${errorCount} errors`);
+}
 
 async function commandFetchAvatars(db: Database, args: CliArgs): Promise<void> {
   console.log("\n🖼️  Fetching Discord Avatar URLs\n");
@@ -1388,6 +1523,9 @@ export async function runUsers(argv: string[] = process.argv.slice(2)) {
         break;
       case "fetch-avatars":
         await commandFetchAvatars(db, args);
+        break;
+      case "sync-profiles":
+        await commandSyncProfiles(db, args);
         break;
       case "build-registry":
         await commandBuildRegistry(db, args);

--- a/src/helpers/dateHelper.ts
+++ b/src/helpers/dateHelper.ts
@@ -99,3 +99,11 @@ export const callbackDateRangeLogic = async (filter: DateConfig, callback: Funct
       }
     }
   }
+
+export const collectDateRange = async (filter: DateConfig): Promise<string[]> => {
+  const dates: string[] = [];
+  await callbackDateRangeLogic(filter, async (dayStr: string) => {
+    dates.push(dayStr);
+  });
+  return dates;
+};

--- a/src/helpers/progressDashboard.ts
+++ b/src/helpers/progressDashboard.ts
@@ -1,0 +1,342 @@
+import readline from "node:readline";
+
+export type DashboardLogLevel =
+  | "info"
+  | "success"
+  | "warning"
+  | "error"
+  | "debug"
+  | "channel";
+
+export interface DashboardTaskState {
+  label: string;
+  status?: string;
+  detail?: string;
+  current?: number;
+  total?: number;
+  startedAt?: number;
+  updatedAt?: number;
+}
+
+interface DashboardEvent {
+  level: DashboardLogLevel;
+  message: string;
+  timestamp: number;
+}
+
+interface DashboardOverallState {
+  label?: string;
+  current?: number;
+  total?: number;
+  detail?: string;
+}
+
+interface ProgressDashboardOptions {
+  title: string;
+  enabled?: boolean;
+  refreshMs?: number;
+  maxTasks?: number;
+  maxEvents?: number;
+}
+
+const LEVEL_LABELS: Record<DashboardLogLevel, string> = {
+  info: "INFO",
+  success: "OK",
+  warning: "WARN",
+  error: "ERR",
+  debug: "DEBUG",
+  channel: "CHAN",
+};
+
+let activeDashboard: ProgressDashboard | null = null;
+
+export function getActiveProgressDashboard(): ProgressDashboard | null {
+  return activeDashboard;
+}
+
+export function setActiveProgressDashboard(dashboard: ProgressDashboard | null): void {
+  activeDashboard = dashboard;
+}
+
+export class ProgressDashboard {
+  private readonly title: string;
+  private readonly enabled: boolean;
+  private readonly refreshMs: number;
+  private readonly maxTasks: number;
+  private readonly maxEvents: number;
+  private readonly startedAt = Date.now();
+  private readonly stats = new Map<string, string>();
+  private readonly tasks = new Map<string, DashboardTaskState>();
+  private readonly events: DashboardEvent[] = [];
+
+  private headerLines: string[] = [];
+  private overall: DashboardOverallState = {};
+  private transientMessage: string | null = null;
+  private renderedLineCount = 0;
+  private renderTimer: NodeJS.Timeout | null = null;
+  private disposed = false;
+
+  constructor(options: ProgressDashboardOptions) {
+    this.title = options.title;
+    this.enabled = options.enabled ?? (Boolean(process.stdout.isTTY) && process.env.TERM !== "dumb");
+    this.refreshMs = options.refreshMs ?? 100;
+    this.maxTasks = options.maxTasks ?? 8;
+    this.maxEvents = options.maxEvents ?? 5;
+  }
+
+  public isInteractive(): boolean {
+    return this.enabled && !this.disposed;
+  }
+
+  public setHeaderLines(lines: string[]): void {
+    this.headerLines = lines.filter(Boolean);
+    this.scheduleRender();
+  }
+
+  public setOverall(state: DashboardOverallState): void {
+    this.overall = {
+      ...this.overall,
+      ...state,
+    };
+    this.scheduleRender();
+  }
+
+  public setStats(stats: Record<string, string | number | undefined>): void {
+    for (const [key, value] of Object.entries(stats)) {
+      if (value === undefined || value === null || value === "") {
+        this.stats.delete(key);
+        continue;
+      }
+      this.stats.set(key, String(value));
+    }
+    this.scheduleRender();
+  }
+
+  public upsertTask(id: string, state: Partial<DashboardTaskState> & { label?: string }): void {
+    const existing = this.tasks.get(id);
+    const startedAt = state.startedAt ?? existing?.startedAt ?? Date.now();
+    this.tasks.set(id, {
+      label: state.label ?? existing?.label ?? id,
+      status: state.status ?? existing?.status,
+      detail: state.detail ?? existing?.detail,
+      current: state.current ?? existing?.current,
+      total: state.total ?? existing?.total,
+      startedAt,
+      updatedAt: Date.now(),
+    });
+    this.scheduleRender();
+  }
+
+  public removeTask(id: string): void {
+    if (this.tasks.delete(id)) {
+      this.scheduleRender();
+    }
+  }
+
+  public clearTasks(): void {
+    if (this.tasks.size === 0) return;
+    this.tasks.clear();
+    this.scheduleRender();
+  }
+
+  public pushEvent(level: DashboardLogLevel, message: string): void {
+    if (level === "debug" && !process.env.DEBUG) {
+      return;
+    }
+
+    this.events.push({
+      level,
+      message,
+      timestamp: Date.now(),
+    });
+
+    if (this.events.length > this.maxEvents) {
+      this.events.splice(0, this.events.length - this.maxEvents);
+    }
+
+    this.scheduleRender();
+  }
+
+  public setTransientMessage(message: string | null): void {
+    this.transientMessage = message;
+    this.scheduleRender();
+  }
+
+  public clearTransientMessage(): void {
+    if (!this.transientMessage) return;
+    this.transientMessage = null;
+    this.scheduleRender();
+  }
+
+  public getStatsSnapshot(): Record<string, string> {
+    return Object.fromEntries(this.stats.entries());
+  }
+
+  public finish(summaryLines: string[] = []): void {
+    this.disposed = true;
+    if (this.renderTimer) {
+      clearTimeout(this.renderTimer);
+      this.renderTimer = null;
+    }
+
+    if (this.enabled) {
+      this.clearRenderedArea();
+    }
+
+    if (summaryLines.length > 0) {
+      process.stdout.write(summaryLines.join("\n") + "\n");
+    }
+
+    if (activeDashboard === this) {
+      activeDashboard = null;
+    }
+  }
+
+  public dispose(): void {
+    this.finish([]);
+  }
+
+  private scheduleRender(): void {
+    if (!this.enabled || this.disposed) return;
+    if (this.renderTimer) return;
+
+    this.renderTimer = setTimeout(() => {
+      this.renderTimer = null;
+      this.render();
+    }, this.refreshMs);
+  }
+
+  private render(): void {
+    if (!this.enabled || this.disposed) return;
+
+    const lines = this.buildLines();
+    if (this.renderedLineCount > 0) {
+      readline.moveCursor(process.stdout, 0, -this.renderedLineCount);
+      readline.cursorTo(process.stdout, 0);
+    }
+    readline.clearScreenDown(process.stdout);
+    process.stdout.write(lines.join("\n") + "\n");
+    this.renderedLineCount = lines.length;
+  }
+
+  private clearRenderedArea(): void {
+    if (!this.enabled || this.renderedLineCount === 0) return;
+    readline.moveCursor(process.stdout, 0, -this.renderedLineCount);
+    readline.cursorTo(process.stdout, 0);
+    readline.clearScreenDown(process.stdout);
+    this.renderedLineCount = 0;
+  }
+
+  private buildLines(): string[] {
+    const width = Math.max(80, process.stdout.columns || 120);
+    const now = Date.now();
+    const lines: string[] = [];
+
+    lines.push(this.truncate(`== ${this.title} ==`, width));
+    lines.push(this.truncate(`Elapsed: ${formatDuration(now - this.startedAt)}`, width));
+
+    for (const line of this.headerLines) {
+      lines.push(this.truncate(line, width));
+    }
+
+    if (this.overall.label || typeof this.overall.current === "number" || typeof this.overall.total === "number") {
+      const total = this.overall.total ?? 0;
+      const current = this.overall.current ?? 0;
+      const bar = total > 0 ? renderBar(current, total, 24) : renderPulse(now);
+      const countText = total > 0 ? `${current}/${total}` : `${current}`;
+      const detail = this.overall.detail ? ` | ${this.overall.detail}` : "";
+      const label = this.overall.label ? ` ${this.overall.label}` : "";
+      lines.push(this.truncate(`Overall: ${bar} ${countText}${label}${detail}`, width));
+    }
+
+    if (this.stats.size > 0) {
+      const statLine = Array.from(this.stats.entries())
+        .map(([key, value]) => `${labelize(key)} ${value}`)
+        .join(" | ");
+      lines.push(this.truncate(`Stats: ${statLine}`, width));
+    }
+
+    if (this.transientMessage) {
+      lines.push(this.truncate(`Progress: ${this.transientMessage}`, width));
+    }
+
+    lines.push("Active Tasks:");
+    if (this.tasks.size === 0) {
+      lines.push("  idle");
+    } else {
+      const orderedTasks = Array.from(this.tasks.values())
+        .sort((a, b) => (b.updatedAt || 0) - (a.updatedAt || 0))
+        .slice(0, this.maxTasks);
+
+      for (const task of orderedTasks) {
+        const parts = [`  ${truncateMiddle(task.label, 18)}`];
+        if (task.status) {
+          parts.push(task.status);
+        }
+        if (task.total && task.total > 0 && typeof task.current === "number") {
+          parts.push(renderBar(task.current, task.total, 10));
+        }
+        if (task.detail) {
+          parts.push(task.detail);
+        }
+        if (task.startedAt) {
+          parts.push(formatDuration(now - task.startedAt));
+        }
+        lines.push(this.truncate(parts.join(" | "), width));
+      }
+    }
+
+    if (this.events.length > 0) {
+      lines.push("Recent Events:");
+      for (const event of this.events) {
+        lines.push(this.truncate(`  [${LEVEL_LABELS[event.level]}] ${event.message}`, width));
+      }
+    }
+
+    return lines;
+  }
+
+  private truncate(value: string, width: number): string {
+    if (value.length <= width) return value;
+    if (width <= 3) return value.slice(0, width);
+    return `${value.slice(0, width - 3)}...`;
+  }
+}
+
+function renderBar(current: number, total: number, width: number): string {
+  const safeTotal = total <= 0 ? 1 : total;
+  const boundedCurrent = Math.max(0, Math.min(current, safeTotal));
+  const filled = Math.round((boundedCurrent / safeTotal) * width);
+  return `[${"=".repeat(filled)}${"-".repeat(width - filled)}]`;
+}
+
+function renderPulse(timestamp: number): string {
+  const frames = ["[>---------]", "[-=>-------]", "[---=>-----]", "[-----=>---]", "[-------=>-]"];
+  return frames[Math.floor(timestamp / 200) % frames.length];
+}
+
+function truncateMiddle(value: string, width: number): string {
+  if (value.length <= width) return value;
+  if (width <= 3) return value.slice(0, width);
+
+  const left = Math.ceil((width - 3) / 2);
+  const right = Math.floor((width - 3) / 2);
+  return `${value.slice(0, left)}...${value.slice(value.length - right)}`;
+}
+
+function labelize(key: string): string {
+  return key.replace(/[_-]+/g, " ");
+}
+
+function formatDuration(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  if (hours > 0) {
+    return `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+  }
+
+  return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+}

--- a/src/historical.ts
+++ b/src/historical.ts
@@ -11,6 +11,7 @@ import { MediaDownloader, generateManifestToFile } from "./download-media";
 import { MediaDownloadCapable } from "./plugins/sources/DiscordRawDataSource";
 import { SummaryEnricher } from "./plugins/enrichers/SummaryEnricher";
 import { logger } from "./helpers/cliHelper";
+import { ProgressDashboard, setActiveProgressDashboard } from "./helpers/progressDashboard";
 import { open } from "sqlite";
 import sqlite3 from "sqlite3";
 import dotenv from "dotenv";
@@ -23,7 +24,7 @@ import {
   loadStorage,
   validateConfiguration
 } from "./helpers/configHelper";
-import { addOneDay, parseDate, formatDate, callbackDateRangeLogic } from "./helpers/dateHelper";
+import { addOneDay, parseDate, formatDate, callbackDateRangeLogic, collectDateRange } from "./helpers/dateHelper";
 
 dotenv.config({ quiet: true });
 
@@ -32,6 +33,88 @@ dotenv.config({ quiet: true });
  */
 function hasMediaDownloadCapability(source: any): source is MediaDownloadCapable & { name: string } {
   return source && typeof source.hasMediaDownloadEnabled === 'function';
+}
+
+function formatDuration(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  if (hours > 0) {
+    return `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+  }
+
+  return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+}
+
+function describeMode(onlyFetch: boolean, onlyGenerate: boolean): string {
+  if (onlyGenerate) return "generate-only";
+  if (onlyFetch) return "fetch-only";
+  return "fetch+generate";
+}
+
+function describeDateScope(fetchDates: string[]): string {
+  if (fetchDates.length === 0) return "none";
+  if (fetchDates.length === 1) return fetchDates[0];
+  return `${fetchDates[fetchDates.length - 1]} -> ${fetchDates[0]}`;
+}
+
+function buildFetchHeaderLines(options: {
+  sourceFile: string;
+  mode: string;
+  fetchDates: string[];
+  outputPath: string;
+  currentSource?: string;
+  currentDate?: string;
+  overrideCount: number;
+}): string[] {
+  const lines = [
+    `Config: ${options.sourceFile} | Mode: ${options.mode} | Dates: ${describeDateScope(options.fetchDates)}`,
+    `Output: ${options.outputPath} | Channel override: ${options.overrideCount > 0 ? `${options.overrideCount} channel(s)` : 'none'}`,
+  ];
+
+  if (options.currentSource || options.currentDate) {
+    lines.push(`Current: ${options.currentSource || '-'} @ ${options.currentDate || '-'}`);
+  }
+
+  return lines;
+}
+
+function buildFetchSummary(options: {
+  sourceFile: string;
+  fetchDates: string[];
+  totalJobs: number;
+  completedJobs: number;
+  startedAt: number;
+  stats: Record<string, string>;
+}): string[] {
+  const summary = [
+    "Historical fetch summary",
+    `  config: ${options.sourceFile}`,
+    `  dates: ${describeDateScope(options.fetchDates)}`,
+    `  source-date jobs: ${options.completedJobs}/${options.totalJobs}`,
+    `  elapsed: ${formatDuration(Date.now() - options.startedAt)}`,
+  ];
+
+  const statLabels: Array<[string, string]> = [
+    ["queued", "queued channels"],
+    ["active", "active channels"],
+    ["done", "completed channels"],
+    ["failed", "failed channels"],
+    ["skip_existing", "skipped existing"],
+    ["skip_unavailable", "skipped unavailable"],
+    ["skip_future", "skipped future"],
+    ["items", "stored items"],
+  ];
+
+  for (const [key, label] of statLabels) {
+    if (options.stats[key] !== undefined) {
+      summary.push(`  ${label}: ${options.stats[key]}`);
+    }
+  }
+
+  return summary;
 }
 
 (async () => {
@@ -53,6 +136,8 @@ function hasMediaDownloadCapability(source: any): source is MediaDownloadCapable
     let dateStr = today.toISOString().slice(0, 10);
     let onlyFetch = false;
     let onlyGenerate = false;
+    let skipExisting = false;
+    let force = false;
     let downloadMedia = false;
     let generateManifest = false;
     let manifestOutput: string | undefined;
@@ -61,6 +146,7 @@ function hasMediaDownloadCapability(source: any): source is MediaDownloadCapable
     let afterDate;
     let duringDate;
     let outputPath = './'; // Default output path
+    let overrideChannels: string[] = [];
 
     if (args.includes('--help') || args.includes('-h')) {
       logger.info(`
@@ -84,6 +170,9 @@ Options:
   --generate-manifest   Generate media manifest JSON for VPS downloads (default: false).
   --manifest-output=<path> Output path for manifest file (default: <output>/media-manifest.json).
   --media-manifest=<path> Path to media manifest for CDN URL enrichment in summaries.
+  --channels=<id1,id2>  Comma-separated channel IDs to override config (archive mode).
+  --skip-existing       Skip generation for dates that already have a summary.
+  -f, --force           Force regeneration even if summary exists (overrides --skip-existing).
   --output=<path>       Output directory path (default: ./)
   -h, --help            Show this help message.
       `);
@@ -130,6 +219,12 @@ Options:
         duringDate = arg.split('=')[1];
       } else if (arg.startsWith('--output=') || arg.startsWith('-o=')) {
         outputPath = arg.split('=')[1];
+      } else if (arg.startsWith('--channels=')) {
+        overrideChannels = arg.split('=')[1].split(',').map(id => id.trim()).filter(Boolean);
+      } else if (arg === '--skip-existing' || arg === '--skip-existing=true') {
+        skipExisting = true;
+      } else if (arg === '-f' || arg === '--force') {
+        force = true;
       }
     });
 

--- a/src/plugins/generators/DiscordSummaryGenerator.ts
+++ b/src/plugins/generators/DiscordSummaryGenerator.ts
@@ -1,5 +1,6 @@
 import { OpenAIProvider } from "../ai/OpenAIProvider";
 import { SQLiteStorage } from "../storage/SQLiteStorage";
+import { DiscordChannelRegistry } from "../storage/DiscordChannelRegistry";
 import { ContentItem, SummaryItem, DiscordSummary, ActionItems, HelpInteractions, SummaryFaqs, DiscordRawData } from "../../types";
 import { writeFile } from "../../helpers/fileHelper";
 import { logger } from "../../helpers/cliHelper";
@@ -18,6 +19,8 @@ export class DiscordSummaryGenerator {
   private summaryType: string;
   private source: string;
   private outputPath: string;
+  private static readonly MIN_CHANNEL_MESSAGES = 3;
+  private static readonly MIN_CHANNEL_HUMAN_USERS = 2;
 
 
   static constructorInterface = {
@@ -131,13 +134,97 @@ export class DiscordSummaryGenerator {
       // Group by channel and process each channel
       const channelItemsMap = this.groupByChannel(contentItems);
       const allChannelSummaries: DiscordSummary[] = [];
-      
-      logger.info(`Processing ${Object.keys(channelItemsMap).length} channels`);
+
+      // DB-driven channel filtering: check isMuted and aiRecommendation
+      let channelRegistry: DiscordChannelRegistry | null = null;
+      const db = this.storage.getDb();
+      if (db) {
+        channelRegistry = new DiscordChannelRegistry(db);
+      }
+
+      const channelSelection: {
+        included: { channelId: string; channelName: string; reason: string }[];
+        excluded: { channelId: string; channelName: string; reason: string }[];
+      } = { included: [], excluded: [] };
+
+      const channelsToProcess: { [channelId: string]: ContentItem[] } = {};
+
       for (const [channelId, items] of Object.entries(channelItemsMap)) {
+        const channelName = items[0]?.metadata?.channelName || 'Unknown';
+        const { messages, users } = this.combineRawData(items);
+        const uniqueHumanUsers = new Set(
+          messages
+            .filter(message => {
+              const user = users[message.uid];
+              return user && !user.isBot;
+            })
+            .map(message => message.uid)
+        ).size;
+
+        if (messages.length === 0) {
+          channelSelection.excluded.push({
+            channelId,
+            channelName,
+            reason: 'No messages that day'
+          });
+          logger.info(`Skipping channel ${channelName} (${channelId}): no messages that day`);
+          continue;
+        }
+
+        if (
+          messages.length < DiscordSummaryGenerator.MIN_CHANNEL_MESSAGES ||
+          uniqueHumanUsers < DiscordSummaryGenerator.MIN_CHANNEL_HUMAN_USERS
+        ) {
+          const reasonParts: string[] = [];
+          if (messages.length < DiscordSummaryGenerator.MIN_CHANNEL_MESSAGES) {
+            reasonParts.push(`${messages.length} message${messages.length === 1 ? '' : 's'}`);
+          }
+          if (uniqueHumanUsers < DiscordSummaryGenerator.MIN_CHANNEL_HUMAN_USERS) {
+            reasonParts.push(`${uniqueHumanUsers} human user${uniqueHumanUsers === 1 ? '' : 's'}`);
+          }
+          channelSelection.excluded.push({
+            channelId,
+            channelName,
+            reason: `Below threshold: ${reasonParts.join(', ')}`
+          });
+          logger.info(`Skipping low-signal channel ${channelName} (${channelId}): ${reasonParts.join(', ')}`);
+          continue;
+        }
+
+        if (channelRegistry) {
+          const channel = await channelRegistry.getChannelById(channelId);
+          if (channel) {
+            if (channel.isMuted) {
+              channelSelection.excluded.push({ channelId, channelName, reason: 'Muted' });
+              logger.info(`Skipping muted channel ${channelName} (${channelId})`);
+              continue;
+            }
+            if (channel.aiRecommendation === 'SKIP') {
+              channelSelection.excluded.push({
+                channelId,
+                channelName,
+                reason: channel.aiReason || 'AI recommended skip'
+              });
+              logger.info(`Skipping AI-SKIP channel ${channelName} (${channelId}): ${channel.aiReason || 'no reason'}`);
+              continue;
+            }
+          }
+        }
+
+        channelsToProcess[channelId] = items;
+        channelSelection.included.push({
+          channelId,
+          channelName,
+          reason: `Active channel: ${messages.length} messages, ${uniqueHumanUsers} human users`
+        });
+      }
+
+      logger.info(`Processing ${Object.keys(channelsToProcess).length} channels (${channelSelection.excluded.length} excluded)`);
+      for (const [channelId, items] of Object.entries(channelsToProcess)) {
         try {
           logger.info(`Processing channel ${channelId} with ${items.length} items`);
           const channelSummary = await this.processChannelData(items);
-          
+
           if (channelSummary) {
             // Add channel ID to the summary for linking with stats
             allChannelSummaries.push({

--- a/src/plugins/storage/DiscordChannelRegistry.ts
+++ b/src/plugins/storage/DiscordChannelRegistry.ts
@@ -962,6 +962,72 @@ export class DiscordChannelRegistry {
     return rows.map(row => this.parseChannelRow(row));
   }
 
+  /**
+   * Rebuild channel stats (lastActivityAt, totalMessages, currentVelocity, activityHistory)
+   * from the items table. Use after bulk imports or when registry stats are stale.
+   */
+  async syncStats(): Promise<{ updated: number }> {
+    // Phase 1: all-time totals and latest fetch date per channel
+    const allStats = await this.db.all<Array<{ ch: string; lastDate: number; total: number }>>(
+      `SELECT
+         substr(cid, 13, length(cid) - 23)                      AS ch,
+         MAX(date)                                               AS lastDate,
+         SUM(CAST(json_extract(metadata, '$.messageCount') AS INTEGER)) AS total
+       FROM items
+       WHERE type = 'discordRawData'
+       GROUP BY substr(cid, 13, length(cid) - 23)`
+    );
+
+    // Phase 2: per-day message counts for last 90 days (for activityHistory + velocity)
+    const cutoff = Math.floor(Date.now() / 1000) - 90 * 86400;
+    const recentRows = await this.db.all<Array<{ ch: string; day: string; cnt: number }>>(
+      `SELECT
+         substr(cid, 13, length(cid) - 23)                       AS ch,
+         substr(cid, length(cid) - 9)                            AS day,
+         CAST(json_extract(metadata, '$.messageCount') AS INTEGER) AS cnt
+       FROM items
+       WHERE type = 'discordRawData' AND date >= ?
+       ORDER BY ch, date DESC`,
+      [cutoff]
+    );
+
+    // Group recent rows by channel
+    const recentByChannel = new Map<string, Array<{ date: string; messageCount: number; velocity: number }>>();
+    for (const row of recentRows) {
+      if (!recentByChannel.has(row.ch)) recentByChannel.set(row.ch, []);
+      recentByChannel.get(row.ch)!.push({ date: row.day, messageCount: row.cnt, velocity: 0 });
+    }
+
+    const now = Math.floor(Date.now() / 1000);
+    let updated = 0;
+
+    for (const stat of allStats) {
+      const history = recentByChannel.get(stat.ch) ?? [];
+
+      // Compute per-entry window velocities
+      for (let i = 0; i < history.length; i++) {
+        const window = history.slice(i, Math.min(i + 7, history.length));
+        history[i].velocity = window.reduce((s, e) => s + e.messageCount, 0) / window.length;
+      }
+
+      const velocity = history.slice(0, 7).reduce((s, e) => s + e.messageCount, 0) / Math.max(history.slice(0, 7).length, 1);
+
+      await this.db.run(
+        `UPDATE discord_channels
+         SET lastActivityAt = ?,
+             totalMessages  = ?,
+             currentVelocity = ?,
+             activityHistory = ?,
+             updatedAt = ?
+         WHERE id = ?`,
+        [stat.lastDate, stat.total, velocity, JSON.stringify(history), now, stat.ch]
+      );
+      updated++;
+    }
+
+    return { updated };
+  }
+
   // ============================================================================
   // Private Helpers
   // ============================================================================


### PR DESCRIPTION
Closes #59 — resolves merge conflicts by applying PR changes onto current main.

## Summary
- New channel CLI commands: `sync`, `mirror`, `archive`, `fix-states`, `sync-stats`
- Channel state model fix: separates bot-inaccessible (`unavailableReason`) from user-muted (`isMuted`)
- `ProgressDashboard` TUI helper for live progress visualization in long-running ops
- `resolveConfigEnvValue()` helper for env var resolution in config strings
- `--skip-existing`, `--force`, `--channels=` flags in `historical.ts`
- `isProfileFresh()`, `buildDiscordProfileMetadata()`, `sync-profiles` command in `users.ts`
- Channel filtering in `DiscordSummaryGenerator` (min 3 messages, min 2 human users)
- `syncStats()` added to `DiscordChannelRegistry` to rebuild stats from items table
- `collectDateRange` helper in `dateHelper.ts`
- Keeps main's `summarize` command (LLM analysis) alongside new `archive` command (historical backfill) — these are different operations
- Adds `docs/community-profiles.md` and `docs/gap-detection-registry-fix.md`

## Test plan
- [x] `npm run channels -- stats --source=m3org.json`
- [x] `npm run channels -- fix-states --dry-run --source=m3org.json`
- [x] `npm run channels -- sync-stats --source=m3org.json` (updated 219 channels)
- [x] `npm run users -- sync-profiles --skip-existing --source=m3org.json`
- [x] `npm run users -- generate-profiles --source=m3org.json --skip-existing`
- [x] `npm run historical -- --source=m3org.json --after=2026-03-20 --before=2026-03-21 --onlyGenerate`
- [x] `npm run build` — no new type errors (pre-existing DiscordRawDataSource.ts errors expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)