### PR TITLE
ci: add test workflow for validating shared workflow dry runs

### DIFF
--- a/.github/workflows/test-data-collection.yml
+++ b/.github/workflows/test-data-collection.yml
@@ -1,0 +1,36 @@
+name: Test Data Collection (Dry Run)
+
+# workflow_dispatch only — pull_request from forks doesn't get secrets.
+# Trigger manually on any branch (including PR branches) to validate.
+# Download artifacts after to inspect public/ directory layout.
+on:
+  workflow_dispatch:
+
+jobs:
+  test-elizaos:
+    uses: ./.github/workflows/data-collection.yml
+    with:
+      source_name: elizaos
+      source_display_name: elizaos
+      historical_output: ./output
+      include_discord_summaries: true
+      commit_message_prefix: "[DRY RUN] ElizaOS"
+      dry_run: true
+    secrets:
+      ENV_SECRETS: ${{ secrets.ENV_SECRETS }}
+      SQLITE_ENCRYPTION_KEY: ${{ secrets.SQLITE_ENCRYPTION_KEY }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  test-hyperfy:
+    uses: ./.github/workflows/data-collection.yml
+    with:
+      source_name: hyperfy-discord
+      source_display_name: hyperfy
+      historical_output: ./output/hyperfy
+      include_discord_summaries: false
+      commit_message_prefix: "[DRY RUN] Hyperfy"
+      dry_run: true
+    secrets:
+      ENV_SECRETS: ${{ secrets.ENV_SECRETS }}
+      SQLITE_ENCRYPTION_KEY: ${{ secrets.SQLITE_ENCRYPTION_KEY }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This workflow is merged first so it exists on main. Once on main, it can be triggered manually on the ci-shared-workflow PR branch to validate the shared workflow's public/ layout before merge.

No production impact — only uploads artifacts, never deploys.