### PR TITLE
fix: remove GITHUB_TOKEN from workflow_call secrets

### DIFF
--- a/.github/workflows/data-collection.yml
+++ b/.github/workflows/data-collection.yml
@@ -48,8 +48,6 @@ on:
         required: true
       SQLITE_ENCRYPTION_KEY:
         required: true
-      GITHUB_TOKEN:
-        required: true
 
 jobs:
   sqlite-job:

--- a/.github/workflows/elizaos.yml
+++ b/.github/workflows/elizaos.yml
@@ -39,4 +39,3 @@ jobs:
     secrets:
       ENV_SECRETS: ${{ secrets.ENV_SECRETS }}
       SQLITE_ENCRYPTION_KEY: ${{ secrets.SQLITE_ENCRYPTION_KEY }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/hyperfy.yml
+++ b/.github/workflows/hyperfy.yml
@@ -39,4 +39,3 @@ jobs:
     secrets:
       ENV_SECRETS: ${{ secrets.ENV_SECRETS }}
       SQLITE_ENCRYPTION_KEY: ${{ secrets.SQLITE_ENCRYPTION_KEY }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-data-collection.yml
+++ b/.github/workflows/test-data-collection.yml
@@ -19,7 +19,7 @@ jobs:
     secrets:
       ENV_SECRETS: ${{ secrets.ENV_SECRETS }}
       SQLITE_ENCRYPTION_KEY: ${{ secrets.SQLITE_ENCRYPTION_KEY }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 
   test-hyperfy:
     uses: ./.github/workflows/data-collection.yml
@@ -33,4 +33,4 @@ jobs:
     secrets:
       ENV_SECRETS: ${{ secrets.ENV_SECRETS }}
       SQLITE_ENCRYPTION_KEY: ${{ secrets.SQLITE_ENCRYPTION_KEY }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
## Summary
- Remove `GITHUB_TOKEN` from `workflow_call` secrets declaration in `data-collection.yml` — it's a system-reserved name that causes workflow queue failures
- Remove explicit `GITHUB_TOKEN` passing from `elizaos.yml`, `hyperfy.yml`, and `test-data-collection.yml` callers
- `GITHUB_TOKEN` is automatically available to called workflows, no explicit passing needed

Fixes: `Failed to queue workflow run: Invalid Argument - failed to parse workflow: secret name GITHUB_TOKEN within workflow_call can not be used since it would collide with system reserved name`

## Test plan
- [ ] Run test-data-collection workflow manually to verify it queues successfully
- [ ] Verify elizaos and hyperfy daily workflows still deploy to gh-pages correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)