### PR TITLE
fix: write placeholder summary on quiet days

### DIFF
--- a/src/plugins/generators/DiscordSummaryGenerator.ts
+++ b/src/plugins/generators/DiscordSummaryGenerator.ts
@@ -125,7 +125,22 @@ export class DiscordSummaryGenerator {
       );
       
       if (contentItems.length === 0) {
-        logger.warning(`No Discord content found for ${dateStr}`);
+        logger.warning(`No Discord content found for ${dateStr}, writing placeholder summary`);
+        const serverName = "Discord Server";
+        const fileTitle = `${serverName} Discord - ${dateStr}`;
+
+        const jsonData = {
+          server: serverName,
+          title: fileTitle,
+          date: startTimeEpoch,
+          stats: { totalMessages: 0, totalUsers: 0 },
+          categories: []
+        };
+
+        const markdown = `# ${fileTitle}\n\nNo significant activity for this period.`;
+
+        await writeFile(this.outputPath, dateStr, JSON.stringify(jsonData, null, 2), 'json');
+        await writeFile(this.outputPath, dateStr, markdown, 'md');
         return;
       }
       
@@ -240,11 +255,30 @@ export class DiscordSummaryGenerator {
       // Generate combined summary file if we have channel summaries
       if (allChannelSummaries.length > 0) {
         await this.generateCombinedSummaryFiles(
-          allChannelSummaries, 
-          dateStr, 
+          allChannelSummaries,
+          dateStr,
           startTimeEpoch,
           contentItems // Pass content items for statistics
         );
+      } else {
+        // All channels below threshold — write placeholder so daily.json stays current
+        logger.info(`No channels met threshold for ${dateStr}, writing placeholder summary`);
+        const serverName = contentItems[0]?.metadata?.guildName || "Discord Server";
+        const fileTitle = `${serverName} Discord - ${dateStr}`;
+
+        const jsonData = {
+          server: serverName,
+          title: fileTitle,
+          date: startTimeEpoch,
+          stats: { totalMessages: 0, totalUsers: 0 },
+          categories: []
+        };
+
+        const markdown = `# ${fileTitle}\n\nNo significant activity for this period.`;
+
+        await writeFile(this.outputPath, dateStr, JSON.stringify(jsonData, null, 2), 'json');
+        await writeFile(this.outputPath, dateStr, markdown, 'md');
+        logger.success(`Wrote placeholder summary for ${dateStr}`);
       }
       
     } catch (error) {


### PR DESCRIPTION
## Summary
- When all Discord channels are below the activity threshold (3 messages, 2 human users), the `DiscordSummaryGenerator` now writes a placeholder JSON + MD file instead of producing no output
- Also handles the zero-content-items case (no Discord data fetched at all)
- Prevents `daily.json`/`daily.md` from going stale — Hyperfy's has been stuck on March 16 data

**Placeholder JSON:**
```json
{ "server": "...", "title": "...", "date": ..., "stats": { "totalMessages": 0, "totalUsers": 0 }, "categories": [] }
```

**Placeholder MD:**
```
# Server Discord - YYYY-MM-DD

No significant activity for this period.
```

No AI calls are made — just writes static files to the standard output paths so the CI deploy step picks them up normally.

## Test plan
- [ ] `npm run build` passes (only pre-existing DiscordRawDataSource.ts errors)
- [ ] Run `npm run historical -- --source=hyperfy-discord.json --date=2026-04-01` and verify placeholder files appear in `output/hyperfy/summaries/json/` and `md/`
- [ ] After merge, run test-data-collection workflow and confirm hyperfy artifact includes `daily.json` with placeholder content

🤖 Generated with [Claude Code](https://claude.com/claude-code)